### PR TITLE
Ensure methods return correct values

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -110,7 +110,7 @@ abstract class AbstractCursor
     {
         $document = $this->ensureIterator()->current();
         if ($document !== null) {
-            $document = TypeConverter::convertObjectToLegacyArray($document);
+            $document = TypeConverter::toLegacy($document);
         }
 
         return $document;

--- a/lib/Alcaeus/MongoDbAdapter/Helper/WriteConcern.php
+++ b/lib/Alcaeus/MongoDbAdapter/Helper/WriteConcern.php
@@ -51,9 +51,9 @@ trait WriteConcern
     /**
      * @param string|int $wstring
      * @param int $wtimeout
-     * @return bool
+     * @return \MongoDB\Driver\WriteConcern
      */
-    protected function setWriteConcernFromParameters($wstring, $wtimeout = 0)
+    protected function createWriteConcernFromParameters($wstring, $wtimeout)
     {
         if (! is_string($wstring) && ! is_int($wstring)) {
             trigger_error("w for WriteConcern must be a string or integer", E_WARNING);
@@ -61,7 +61,17 @@ trait WriteConcern
         }
 
         // Ensure wtimeout is not < 0
-        $this->writeConcern = new \MongoDB\Driver\WriteConcern($wstring, max($wtimeout, 0));
+        return new \MongoDB\Driver\WriteConcern($wstring, max($wtimeout, 0));
+    }
+
+    /**
+     * @param string|int $wstring
+     * @param int $wtimeout
+     * @return bool
+     */
+    protected function setWriteConcernFromParameters($wstring, $wtimeout = 0)
+    {
+        $this->writeConcern = $this->createWriteConcernFromParameters($wstring, $wtimeout);
 
         return true;
     }

--- a/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
@@ -49,7 +49,20 @@ class TypeConverter
         switch (true) {
             case $value instanceof \MongoDB\BSON\ObjectID:
                 return new \MongoId($value);
-
+            case $value instanceof \MongoDB\BSON\Binary:
+                return new \MongoBinData($value);
+            case $value instanceof \MongoDB\BSON\Javascript:
+                return new \MongoCode($value);
+            case $value instanceof \MongoDB\BSON\MaxKey:
+                return new \MongoMaxKey();
+            case $value instanceof \MongoDB\BSON\MinKey:
+                return new \MongoMinKey();
+            case $value instanceof \MongoDB\BSON\Regex:
+                return new \MongoRegex($value);
+            case $value instanceof \MongoDB\BSON\Timestamp:
+                return new \MongoTimestamp($value);
+            case $value instanceof \MongoDB\BSON\UTCDatetime:
+                return new \MongoDate($value);
             default:
                 return $value;
         }

--- a/lib/Mongo/Mongo.php
+++ b/lib/Mongo/Mongo.php
@@ -198,6 +198,18 @@ class Mongo extends MongoClient
     }
 
     /**
+     * Choose a new secondary for slaveOkay reads
+     *
+     * @link www.php.net/manual/en/mongo.switchslave.php
+     * @return string The address of the secondary this connection is using for reads. This may be the same as the previous address as addresses are randomly chosen. It may return only one address if only one secondary (or only the primary) is available.
+     * @throws MongoException (error code 15) if it is called on a non-replica-set connection. It will also throw MongoExceptions if it cannot find anyone (primary or secondary) to read from (error code 16).
+     */
+    public function switchSlave()
+    {
+        $this->notImplemented();
+    }
+
+    /**
      * Creates a database error on the database.
      *
      * @link http://www.php.net/manual/en/mongo.forceerror.php

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -291,18 +291,6 @@ class MongoClient
     }
 
     /**
-     * Choose a new secondary for slaveOkay reads
-     *
-     * @link www.php.net/manual/en/mongo.switchslave.php
-     * @return string The address of the secondary this connection is using for reads. This may be the same as the previous address as addresses are randomly chosen. It may return only one address if only one secondary (or only the primary) is available.
-     * @throws MongoException (error code 15) if it is called on a non-replica-set connection. It will also throw MongoExceptions if it cannot find anyone (primary or secondary) to read from (error code 16).
-     */
-    public function switchSlave()
-    {
-        $this->notImplemented();
-    }
-
-    /**
      * String representation of this connection
      *
      * @link http://www.php.net/manual/en/mongoclient.tostring.php

--- a/lib/Mongo/MongoCode.php
+++ b/lib/Mongo/MongoCode.php
@@ -13,7 +13,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-class MongoCode
+class MongoCode implements \Alcaeus\MongoDbAdapter\TypeInterface
 {
     /**
      * @var string
@@ -32,6 +32,11 @@ class MongoCode
      */
     public function __construct($code, array $scope = [])
     {
+        if ($code instanceof \MongoDB\BSON\Javascript) {
+            // @todo Use properties from object once they are accessible
+            $code = '';
+        }
+
         $this->code = $code;
         $this->scope = $scope;
     }
@@ -43,5 +48,16 @@ class MongoCode
     public function __toString()
     {
         return $this->code;
+    }
+
+    /**
+     * Converts this MongoCode to the new BSON JavaScript type
+     *
+     * @return \MongoDB\BSON\Javascript
+     * @internal This method is not part of the ext-mongo API
+     */
+    public function toBSONType()
+    {
+        return new \MongoDB\BSON\Javascript($this->code, $this->scope);
     }
 }

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -648,7 +648,7 @@ class MongoCollection
      * @link http://www.php.net/manual/en/mongocollection.group.php
      * @param mixed $keys Fields to group by. If an array or non-code object is passed, it will be the key used to group results.
      * @param array $initial Initial value of the aggregation counter object.
-     * @param MongoCode $reduce A function that aggregates (reduces) the objects iterated.
+     * @param MongoCode|string $reduce A function that aggregates (reduces) the objects iterated.
      * @param array $condition An condition that must be true for a row to be considered.
      * @return array
      */
@@ -657,9 +657,7 @@ class MongoCollection
         if (is_string($reduce)) {
             $reduce = new MongoCode($reduce);
         }
-        if ( ! $reduce instanceof MongoCode) {
-            throw new \InvalidArgumentExcption('reduce parameter should be a string or MongoCode instance.');
-        }
+
         $command = [
             'group' => [
                 'ns' => $this->name,

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -406,6 +406,7 @@ class MongoCollection
 
     /**
      * Update a document and return it
+     *
      * @link http://www.php.net/manual/ru/mongocollection.findandmodify.php
      * @param array $query The query criteria to search for.
      * @param array $update The update criteria.
@@ -442,6 +443,7 @@ class MongoCollection
 
     /**
      * Querys this collection, returning a single element
+     *
      * @link http://www.php.net/manual/en/mongocollection.findone.php
      * @param array $query The fields for which to search.
      * @param array $fields Fields of the results to return.
@@ -462,6 +464,7 @@ class MongoCollection
 
     /**
      * Creates an index on the given field(s), or does nothing if the index already exists
+     *
      * @link http://www.php.net/manual/en/mongocollection.createindex.php
      * @param array $keys Field or fields to use as index.
      * @param array $options [optional] This parameter is an associative array of the form array("optionname" => <boolean>, ...).
@@ -483,12 +486,13 @@ class MongoCollection
     }
 
     /**
-     * @deprecated Use MongoCollection::createIndex() instead.
      * Creates an index on the given field(s), or does nothing if the index already exists
+     *
      * @link http://www.php.net/manual/en/mongocollection.ensureindex.php
      * @param array $keys Field or fields to use as index.
      * @param array $options [optional] This parameter is an associative array of the form array("optionname" => <boolean>, ...).
      * @return boolean always true
+     * @deprecated Use MongoCollection::createIndex() instead.
      */
     public function ensureIndex(array $keys, array $options = [])
     {
@@ -499,6 +503,7 @@ class MongoCollection
 
     /**
      * Deletes an index from this collection
+     *
      * @link http://www.php.net/manual/en/mongocollection.deleteindex.php
      * @param string|array $keys Field or fields from which to delete the index.
      * @return array Returns the database response.
@@ -518,6 +523,7 @@ class MongoCollection
 
     /**
      * Delete all indexes for this collection
+     *
      * @link http://www.php.net/manual/en/mongocollection.deleteindexes.php
      * @return array Returns the database response.
      */
@@ -528,6 +534,7 @@ class MongoCollection
 
     /**
      * Returns an array of index names for this collection
+     *
      * @link http://www.php.net/manual/en/mongocollection.getindexinfo.php
      * @return array Returns a list of index names.
      */
@@ -547,6 +554,7 @@ class MongoCollection
 
     /**
      * Counts the number of documents in this collection
+     *
      * @link http://www.php.net/manual/en/mongocollection.count.php
      * @param array|stdClass $query
      * @param array $options
@@ -706,6 +714,8 @@ class MongoCollection
     }
 
     /**
+     * Converts legacy write concern options to a WriteConcern object
+     *
      * @param array $options
      * @return array
      */

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -590,12 +590,30 @@ class MongoCollection
      * Creates a database reference
      *
      * @link http://www.php.net/manual/en/mongocollection.createdbref.php
-     * @param array $a Object to which to create a reference.
+     * @param array|object $document_or_id Object to which to create a reference.
      * @return array Returns a database reference array.
      */
-    public function createDBRef(array $a)
+    public function createDBRef($document_or_id)
     {
-        return \MongoDBRef::create($this->name, $a['_id']);
+        if ($document_or_id instanceof \MongoId) {
+            $id = $document_or_id;
+        } elseif (is_object($document_or_id)) {
+            if (! isset($document_or_id->_id)) {
+                return null;
+            }
+
+            $id = $document_or_id->_id;
+        } elseif (is_array($document_or_id)) {
+            if (! isset($document_or_id['_id'])) {
+                return null;
+            }
+
+            $id = $document_or_id['_id'];
+        } else {
+            $id = $document_or_id;
+        }
+
+        return MongoDBRef::create($this->name, $id);
     }
 
     /**
@@ -607,7 +625,7 @@ class MongoCollection
      */
     public function getDBRef(array $ref)
     {
-        return \MongoDBRef::get($this->db, $ref);
+        return $this->db->getDBRef($ref);
     }
 
     /**

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -508,7 +508,7 @@ class MongoCollection
         if (is_string($keys)) {
             $indexName = $keys;
         } elseif (is_array($keys)) {
-            $indexName = self::toIndexString($keys);
+            $indexName = \MongoDB\generate_index_name($keys);
         } else {
             throw new \InvalidArgumentException();
         }
@@ -626,20 +626,6 @@ class MongoCollection
     public function getDBRef(array $ref)
     {
         return $this->db->getDBRef($ref);
-    }
-
-    /**
-     * @param mixed $keys
-     * @static
-     * @return string
-     */
-    protected static function toIndexString($keys)
-    {
-        $result = '';
-        foreach ($keys as $name => $direction) {
-            $result .= sprintf('%s_%d', $name, $direction);
-        }
-        return $result;
     }
 
     /**

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -572,18 +572,18 @@ class MongoCollection
     public function save($a, array $options = [])
     {
         if (is_object($a)) {
-            $a = (array)$a;
+            $a = (array) $a;
         }
+
         if ( ! array_key_exists('_id', $a)) {
             $id = new \MongoId();
         } else {
             $id = $a['_id'];
             unset($a['_id']);
         }
-        $filter = ['_id' => $id];
-        $filter = TypeConverter::convertLegacyArrayToObject($filter);
-        $a = TypeConverter::convertLegacyArrayToObject($a);
-        return $this->collection->updateOne($filter, ['$set' => $a], ['upsert' => true]);
+        $options['upsert'] = true;
+
+        return $this->update(['_id' => $id], ['$set' => $a], $options);
     }
 
     /**

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -170,9 +170,8 @@ class MongoCollection
         ];
 
         // Convert cursor option
-        if (! isset($options['cursor']) || $options['cursor'] === true || $options['cursor'] === []) {
-            // Cursor option needs to be an object convert bools and empty arrays since those won't be handled by TypeConverter
-            $options['cursor'] = new \stdClass;
+        if (! isset($options['cursor'])) {
+            $options['cursor'] = true;
         }
 
         $command += $options;
@@ -224,7 +223,7 @@ class MongoCollection
      */
     public function drop()
     {
-        return TypeConverter::convertObjectToLegacyArray($this->collection->drop());
+        return TypeConverter::toLegacy($this->collection->drop());
     }
 
     /**
@@ -258,7 +257,7 @@ class MongoCollection
     public function insert($a, array $options = [])
     {
         $result = $this->collection->insertOne(
-            TypeConverter::convertLegacyArrayToObject($a),
+            TypeConverter::fromLegacy($a),
             $this->convertWriteConcernOptions($options)
         );
 
@@ -286,7 +285,7 @@ class MongoCollection
     public function batchInsert(array $a, array $options = [])
     {
         $result = $this->collection->insertMany(
-            TypeConverter::convertLegacyArrayToObject($a),
+            TypeConverter::fromLegacy($a),
             $this->convertWriteConcernOptions($options)
         );
 
@@ -322,8 +321,8 @@ class MongoCollection
 
         /** @var \MongoDB\UpdateResult $result */
         $result = $this->collection->$method(
-            TypeConverter::convertLegacyArrayToObject($criteria),
-            TypeConverter::convertLegacyArrayToObject($newobj),
+            TypeConverter::fromLegacy($criteria),
+            TypeConverter::fromLegacy($newobj),
             $this->convertWriteConcernOptions($options)
         );
 
@@ -359,7 +358,7 @@ class MongoCollection
 
         /** @var \MongoDB\DeleteResult $result */
         $result = $this->collection->$method(
-            TypeConverter::convertLegacyArrayToObject($criteria),
+            TypeConverter::fromLegacy($criteria),
             $this->convertWriteConcernOptions($options)
         );
 
@@ -401,7 +400,7 @@ class MongoCollection
      */
     public function distinct($key, array $query = [])
     {
-        return array_map([TypeConverter::class, 'convertToLegacyType'], $this->collection->distinct($key, $query));
+        return array_map([TypeConverter::class, 'toLegacy'], $this->collection->distinct($key, $query));
     }
 
     /**
@@ -416,26 +415,26 @@ class MongoCollection
      */
     public function findAndModify(array $query, array $update = null, array $fields = null, array $options = [])
     {
-        $query = TypeConverter::convertLegacyArrayToObject($query);
+        $query = TypeConverter::fromLegacy($query);
 
         if (isset($options['remove'])) {
             unset($options['remove']);
             $document = $this->collection->findOneAndDelete($query, $options);
         } else {
-            $update = is_array($update) ? TypeConverter::convertLegacyArrayToObject($update) : [];
+            $update = is_array($update) ? TypeConverter::fromLegacy($update) : [];
 
             if (isset($options['new'])) {
                 $options['returnDocument'] = \MongoDB\Operation\FindOneAndUpdate::RETURN_DOCUMENT_AFTER;
                 unset($options['new']);
             }
 
-            $options['projection'] = is_array($fields) ? TypeConverter::convertLegacyArrayToObject($fields) : [];
+            $options['projection'] = is_array($fields) ? TypeConverter::fromLegacy($fields) : [];
 
             $document = $this->collection->findOneAndUpdate($query, $update, $options);
         }
 
         if ($document) {
-            $document = TypeConverter::convertObjectToLegacyArray($document);
+            $document = TypeConverter::toLegacy($document);
         }
 
         return $document;
@@ -454,9 +453,9 @@ class MongoCollection
     {
         $options = ['projection' => $fields] + $options;
 
-        $document = $this->collection->findOne(TypeConverter::convertLegacyArrayToObject($query), $options);
+        $document = $this->collection->findOne(TypeConverter::fromLegacy($query), $options);
         if ($document !== null) {
-            $document = TypeConverter::convertObjectToLegacyArray($document);
+            $document = TypeConverter::toLegacy($document);
         }
 
         return $document;
@@ -518,7 +517,7 @@ class MongoCollection
             throw new \InvalidArgumentException();
         }
 
-        return TypeConverter::convertObjectToLegacyArray($this->collection->dropIndex($indexName));
+        return TypeConverter::toLegacy($this->collection->dropIndex($indexName));
     }
 
     /**
@@ -529,7 +528,7 @@ class MongoCollection
      */
     public function deleteIndexes()
     {
-        return TypeConverter::convertObjectToLegacyArray($this->collection->dropIndexes());
+        return TypeConverter::toLegacy($this->collection->dropIndexes());
     }
 
     /**
@@ -562,7 +561,7 @@ class MongoCollection
      */
     public function count($query = [], array $options = [])
     {
-        return $this->collection->count(TypeConverter::convertLegacyArrayToObject($query), $options);
+        return $this->collection->count(TypeConverter::fromLegacy($query), $options);
     }
 
     /**

--- a/lib/Mongo/MongoCommandCursor.php
+++ b/lib/Mongo/MongoCommandCursor.php
@@ -53,7 +53,14 @@ class MongoCommandCursor extends AbstractCursor implements MongoCursorInterface
     protected function ensureCursor()
     {
         if ($this->cursor === null) {
-            $this->cursor = $this->db->command(TypeConverter::convertLegacyArrayToObject($this->command), $this->getOptions());
+            $convertedCommand = TypeConverter::fromLegacy($this->command);
+            if (isset($convertedCommand->cursor)) {
+                if ($convertedCommand->cursor === true || $convertedCommand->cursor === []) {
+                    $convertedCommand->cursor = new \stdClass();
+                }
+            }
+
+            $this->cursor = $this->db->command($convertedCommand, $this->getOptions());
         }
 
         return $this->cursor;

--- a/lib/Mongo/MongoDB.php
+++ b/lib/Mongo/MongoDB.php
@@ -221,7 +221,7 @@ class MongoDB
      */
     public function drop()
     {
-        return TypeConverter::convertObjectToLegacyArray($this->db->drop());
+        return TypeConverter::toLegacy($this->db->drop());
     }
 
     /**
@@ -279,7 +279,7 @@ class MongoDB
             $coll = $coll->getName();
         }
 
-        return TypeConverter::convertObjectToLegacyArray($this->db->dropCollection((string) $coll));
+        return TypeConverter::toLegacy($this->db->dropCollection((string) $coll));
     }
 
     /**

--- a/lib/Mongo/MongoDB.php
+++ b/lib/Mongo/MongoDB.php
@@ -14,6 +14,7 @@
  */
 
 use Alcaeus\MongoDbAdapter\Helper;
+use Alcaeus\MongoDbAdapter\TypeConverter;
 use MongoDB\Model\CollectionInfo;
 
 /**
@@ -220,7 +221,7 @@ class MongoDB
      */
     public function drop()
     {
-        return $this->db->drop();
+        return TypeConverter::convertObjectToLegacyArray($this->db->drop());
     }
 
     /**
@@ -233,7 +234,7 @@ class MongoDB
      */
     public function repair($preserve_cloned_files = FALSE, $backup_original_files = FALSE)
     {
-        return [];
+        $this->notImplemented();
     }
 
     /**
@@ -278,7 +279,7 @@ class MongoDB
             $coll = $coll->getName();
         }
 
-        return $this->db->dropCollection((string) $coll);
+        return TypeConverter::convertObjectToLegacyArray($this->db->dropCollection((string) $coll));
     }
 
     /**

--- a/lib/Mongo/MongoDB.php
+++ b/lib/Mongo/MongoDB.php
@@ -116,9 +116,36 @@ class MongoDB
     }
 
     /**
+     * Returns information about collections in this database
+     *
+     * @link http://www.php.net/manual/en/mongodb.getcollectioninfo.php
+     * @param array $options An array of options for listing the collections.
+     * @return array
+     */
+    public function getCollectionInfo(array $options = [])
+    {
+        // The includeSystemCollections option is no longer supported
+        if (isset($options['includeSystemCollections'])) {
+            unset($options['includeSystemCollections']);
+        }
+
+        $collections = $this->db->listCollections($options);
+
+        $getCollectionInfo = function (CollectionInfo $collectionInfo) {
+            return [
+                'name' => $collectionInfo->getName(),
+                'options' => $collectionInfo->getOptions(),
+            ];
+        };
+
+        return array_map($getCollectionInfo, iterator_to_array($collections));
+    }
+
+    /**
      * Get all collections from this database
      *
      * @link http://www.php.net/manual/en/mongodb.getcollectionnames.php
+     * @param array $options An array of options for listing the collections.
      * @return array Returns the names of the all the collections in the database as an array
      */
     public function getCollectionNames(array $options = [])
@@ -134,7 +161,7 @@ class MongoDB
             return $collectionInfo->getName();
         };
 
-        return array_map($getCollectionName, (array)$collections);
+        return array_map($getCollectionName, iterator_to_array($collections));
     }
 
     /**
@@ -259,7 +286,7 @@ class MongoDB
      *
      * @link http://www.php.net/manual/en/mongodb.listcollections.php
      * @param array $options
-     * @return array Returns a list of MongoCollections.
+     * @return MongoCollection[] Returns a list of MongoCollections.
      */
     public function listCollections(array $options = [])
     {

--- a/tests/Alcaeus/MongoDbAdapter/MongoCodeTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCodeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Alcaeus\MongoDbAdapter\Tests;
+
+/**
+ * @author alcaeus <alcaeus@alcaeus.org>
+ */
+class MongoCodeTest extends TestCase
+{
+    public function testCreate()
+    {
+        $code = new \MongoCode('code', ['scope' => 'bleh']);
+        $this->assertAttributeSame('code', 'code', $code);
+        $this->assertAttributeSame(['scope' => 'bleh'], 'scope', $code);
+
+        $this->assertSame('code', (string) $code);
+
+        $bsonCode = $code->toBSONType();
+        $this->assertInstanceOf('MongoDB\BSON\Javascript', $bsonCode);
+    }
+
+    public function testCreateWithBsonObject()
+    {
+        $bsonCode = new \MongoDB\BSON\Javascript('code', ['scope' => 'bleh']);
+        $code = new \MongoCode($bsonCode);
+
+        $this->assertAttributeSame('', 'code', $code);
+        $this->assertAttributeSame([], 'scope', $code);
+    }
+}

--- a/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
@@ -27,7 +27,7 @@ class MongoCommandCursorTest extends TestCase
                         '$match' => ['foo' => 'bar']
                     ]
                 ],
-                'cursor' => new \stdClass()
+                'cursor' => true,
             ],
             'fields' => null,
             'started_iterating' => false,

--- a/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
@@ -128,4 +128,38 @@ class MongoDBTest extends TestCase
         $this->getCollection()->insert(['foo' => 'bar']);
         $this->assertEquals(['ok' => 1, 'retval' => 1], $db->execute("return db.test.count();"));
     }
+
+    public function testGetCollectionNames()
+    {
+        $this->getCollection()->insert(['foo' => 'bar']);
+        $this->assertContains('test', $this->getDatabase()->getCollectionNames());
+    }
+
+    public function testGetCollectionInfo()
+    {
+        $this->getCollection()->insert(['foo' => 'bar']);
+
+        foreach ($this->getDatabase()->getCollectionInfo() as $collectionInfo) {
+            if ($collectionInfo['name'] === 'test') {
+                $this->assertSame(['name' => 'test', 'options' => []], $collectionInfo);
+                return;
+            }
+        }
+
+        $this->fail('The test collection was not found');
+    }
+
+    public function testListCollections()
+    {
+        $this->getCollection()->insert(['foo' => 'bar']);
+        foreach ($this->getDatabase()->listCollections() as $collection) {
+            $this->assertInstanceOf('MongoCollection', $collection);
+
+            if ($collection->getName() === 'test') {
+                return;
+            }
+        }
+
+        $this->fail('The test collection was not found');
+    }
 }

--- a/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
@@ -162,4 +162,21 @@ class MongoDBTest extends TestCase
 
         $this->fail('The test collection was not found');
     }
+
+    public function testDrop()
+    {
+        $this->getCollection()->insert(['foo' => 'bar']);
+        $this->assertSame(['dropped' => 'mongo-php-adapter', 'ok' => 1.0], $this->getDatabase()->drop());
+    }
+
+    public function testDropCollection()
+    {
+        $this->getCollection()->insert(['foo' => 'bar']);
+        $expected = [
+            'ns' => (string) $this->getCollection(),
+            'nIndexesWas' => 1,
+            'ok' => 1.0
+        ];
+        $this->assertSame($expected, $this->getDatabase()->dropCollection('test'));
+    }
 }


### PR DESCRIPTION
Reference: #6.

This starts to ensure correct return types for methods in the Mongo classes. This PR aims to fix return types in the `MongoClient`, `MongoDB` and `MongoCollection` classes.