### PR TITLE
Ensure array is given to insertMany()

### DIFF
--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -285,7 +285,7 @@ class MongoCollection
     public function batchInsert(array $a, array $options = [])
     {
         $result = $this->collection->insertMany(
-            TypeConverter::fromLegacy($a),
+            TypeConverter::fromLegacy(array_values($a)),
             $this->convertWriteConcernOptions($options)
         );
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -61,6 +61,24 @@ class MongoCollectionTest extends TestCase
         $this->assertSame($expected, $this->getCollection()->batchInsert($documents));
     }
 
+    public function testInsertManyWithNonNumericKeys()
+    {
+        $expected = [
+            'connectionId' => 0,
+            'n' => 0,
+            'syncMillis' => 0,
+            'writtenTo' => null,
+            'err' => null,
+            'errmsg' => null
+        ];
+
+        $documents = [
+            'a' => ['foo' => 'bar'],
+            'b' => ['bar' => 'foo']
+        ];
+        $this->assertSame($expected, $this->getCollection()->batchInsert($documents));
+    }
+
     public function testUpdateOne()
     {
         $this->getCollection()->insert(['foo' => 'bar']);


### PR DESCRIPTION
Fixes #23.

This fixes the original issue, I'll have to see if there are other occurences where we need to ensure numeric keys.