### PR TITLE
Pass paremeters to write methods by reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ root:
  - The [createIndex](https://secure.php.net/manual/en/mongocollection.createindex.php)
  method does not yet return the same result as the original method. Instead, it
  always returns the name of the index created.
+ - The [insert](https://php.net/manual/en/mongocollection.insert.php),
+ [batchInsert](https://php.net/manual/en/mongocollection.batchinsert.php),
+ and [save](https://php.net/manual/en/mongocollection.save.php)
+ methods take the first argument by reference. While the original API does not
+ explicitely specify by-reference arguments it does add an ID field to the
+ objects and documents given.
  - The [parallelCollectionScan](https://php.net/manual/en/mongocollection.parallelcollectionscan.php)
  method is not yet implemented.
 

--- a/README.md
+++ b/README.md
@@ -47,48 +47,50 @@ root:
 
 ## MongoClient
 
- - The [MongoClient::connect](https://php.net/manual/de/mongoclient.connect.php)
- and [MongoClient::close](https://secure.php.net/manual/de/mongoclient.close.php)
- methods are not implemented because the underlying driver connects lazily and
- does not offer methods for connecting disconnecting.
- - The [MongoClient::getConnections](https://secure.php.net/manual/de/mongoclient.getconnections.php)
+ - The [connect](https://php.net/manual/en/mongoclient.connect.php) and
+ [close](https://secure.php.net/manual/en/mongoclient.close.php) methods are not
+ implemented because the underlying driver connects lazily and does not offer
+ methods for connecting disconnecting.
+ - The [getConnections](https://secure.php.net/manual/en/mongoclient.getconnections.php)
  method is not implemented because the underlying driver does not offer a method
  to retrieve this data.
- - The [MongoClient::killCursor](https://php.net/manual/de/mongoclient.killcursor.php)
- method is not yet implemented.
+ - The [killCursor](https://php.net/manual/en/mongoclient.killcursor.php) method
+ is not yet implemented.
 
 ## MongoDB
- - The [MongoDB::authenticate](https://secure.php.net/manual/de/mongodb.authenticate.php)
+ - The [authenticate](https://secure.php.net/manual/en/mongodb.authenticate.php)
  method is not supported. To connect to a database with authentication, please
  supply the credentials using the connection string.
- - The `includeSystemCollections` parameter used in the [MongoDB::getCollectionInfo](https://php.net/manual/de/mongodb.getcollectioninfo.php]),
- [MongoDB::getCollectionNames](https://php.net/manual/de/mongodb.getcollectionnames.php]),
- and [MongoDB::listCollections](https://php.net/manual/de/mongodb.listcollections.php)
+ - The `includeSystemCollections` parameter used in the [getCollectionInfo](https://php.net/manual/en/mongodb.getcollectioninfo.php]),
+ [getCollectionNames](https://php.net/manual/en/mongodb.getcollectionnames.php]),
+ and [listCollections](https://php.net/manual/en/mongodb.listcollections.php)
  methods is ignored. These methods do not return information about system
  collections.
- - The [MongoDB::repair](https://secure.php.net/manual/de/mongodb.repair.php)
+ - The [repair](https://secure.php.net/manual/en/mongodb.repair.php)
  method is not yet implemented.
 
 ## MongoCollection
 
- - The [MongoCollection::createIndex](https://secure.php.net/manual/de/mongocollection.createindex.php)
+ - The [createIndex](https://secure.php.net/manual/en/mongocollection.createindex.php)
  method does not yet return the same result as the original method. Instead, it
  always returns the name of the index created.
+ - The [parallelCollectionScan](https://php.net/manual/en/mongocollection.parallelcollectionscan.php)
+ method is not yet implemented.
 
 ## MongoCursor
- - The [MongoCursor::explain](https://php.net/manual/de/mongocursor.explain.php)
+ - The [explain](https://php.net/manual/en/mongocursor.explain.php)
  method is not yet implemented.
- - The [MongoCursor::hasNext](https://php.net/manual/de/mongocursor.hasnext.php)
+ - The [hasNext](https://php.net/manual/en/mongocursor.hasnext.php)
  method is not yet implemented.
- - The [MongoCursor::setFlag](https://php.net/manual/de/mongocursor.setflag.php)
+ - The [setFlag](https://php.net/manual/en/mongocursor.setflag.php)
  method is not yet implemented.
 
 ## MongoCommandCursor
- - The [MongoCommandCursor::createFromDocument](https://php.net/manual/de/mongocommandcursor.createfromdocument.php)
+ - The [createFromDocument](https://php.net/manual/en/mongocommandcursor.createfromdocument.php)
  method is not yet implemented.
 
 ## Types
 
- - Return values containing objects of the [MongoDB\BSON\Javascript](https://secure.php.net/manual/de/class.mongodb-bson-javascript.php)
- class cannot be converted to full [MongoCode](https://secure.php.net/manual/de/class.mongocode.php)
+ - Return values containing objects of the [MongoDB\BSON\Javascript](https://secure.php.net/manual/en/class.mongodb-bson-javascript.php)
+ class cannot be converted to full [MongoCode](https://secure.php.net/manual/en/class.mongocode.php)
  objects because there are no accessors for the code and scope properties.

--- a/tests/Alcaeus/MongoDbAdapter/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoClientTest.php
@@ -82,7 +82,8 @@ class MongoClientTest extends TestCase
 
     public function testListDBs()
     {
-        $this->getCollection()->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $this->getCollection()->insert($document);
         $databases = $this->getClient()->listDBs();
 
         $this->assertSame(1.0, $databases['ok']);

--- a/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
@@ -50,17 +50,4 @@ class MongoCommandCursorTest extends TestCase
 
         $this->assertEquals($expected, $cursor->info());
     }
-
-    /**
-     * @return \MongoCollection
-     */
-    protected function prepareData()
-    {
-        $collection = $this->getCollection();
-
-        $collection->insert(['foo' => 'bar']);
-        $collection->insert(['foo' => 'bar']);
-        $collection->insert(['foo' => 'foo']);
-        return $collection;
-    }
 }

--- a/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
@@ -255,17 +255,4 @@ class MongoCursorTest extends TestCase
     {
         return $this->getMock('MongoDB\Collection', [], [], '', false);
     }
-
-    /**
-     * @return \MongoCollection
-     */
-    protected function prepareData()
-    {
-        $collection = $this->getCollection();
-
-        $collection->insert(['foo' => 'bar']);
-        $collection->insert(['foo' => 'bar']);
-        $collection->insert(['foo' => 'foo']);
-        return $collection;
-    }
 }

--- a/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
@@ -125,19 +125,22 @@ class MongoDBTest extends TestCase
     public function testExecute()
     {
         $db = $this->getDatabase();
-        $this->getCollection()->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $this->getCollection()->insert($document);
         $this->assertEquals(['ok' => 1, 'retval' => 1], $db->execute("return db.test.count();"));
     }
 
     public function testGetCollectionNames()
     {
-        $this->getCollection()->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $this->getCollection()->insert($document);
         $this->assertContains('test', $this->getDatabase()->getCollectionNames());
     }
 
     public function testGetCollectionInfo()
     {
-        $this->getCollection()->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $this->getCollection()->insert($document);
 
         foreach ($this->getDatabase()->getCollectionInfo() as $collectionInfo) {
             if ($collectionInfo['name'] === 'test') {
@@ -151,7 +154,8 @@ class MongoDBTest extends TestCase
 
     public function testListCollections()
     {
-        $this->getCollection()->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $this->getCollection()->insert($document);
         foreach ($this->getDatabase()->listCollections() as $collection) {
             $this->assertInstanceOf('MongoCollection', $collection);
 
@@ -165,13 +169,15 @@ class MongoDBTest extends TestCase
 
     public function testDrop()
     {
-        $this->getCollection()->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $this->getCollection()->insert($document);
         $this->assertSame(['dropped' => 'mongo-php-adapter', 'ok' => 1.0], $this->getDatabase()->drop());
     }
 
     public function testDropCollection()
     {
-        $this->getCollection()->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $this->getCollection()->insert($document);
         $expected = [
             'ns' => (string) $this->getCollection(),
             'nIndexesWas' => 1,

--- a/tests/Alcaeus/MongoDbAdapter/MongoDeleteBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoDeleteBatchTest.php
@@ -9,8 +9,10 @@ class MongoDeleteBatchTest extends TestCase
         $collection = $this->getCollection();
         $batch = new \MongoDeleteBatch($collection);
 
-        $collection->insert(['foo' => 'bar']);
-        $collection->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $collection->insert($document);
+        unset($document['_id']);
+        $collection->insert($document);
 
         $this->assertTrue($batch->add(['q' => ['foo' => 'bar'], 'limit' => 1]));
 
@@ -34,8 +36,10 @@ class MongoDeleteBatchTest extends TestCase
         $collection = $this->getCollection();
         $batch = new \MongoDeleteBatch($collection);
 
-        $collection->insert(['foo' => 'bar']);
-        $collection->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $collection->insert($document);
+        unset($document['_id']);
+        $collection->insert($document);
 
         $this->assertTrue($batch->add(['q' => ['foo' => 'bar'], 'limit' => 0]));
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoGridFSTest.php
@@ -23,8 +23,10 @@ class MongoGridFSTest extends TestCase
     {
         $collection = $this->getGridFS();
 
-        $collection->insert(['foo' => 'bar']);
-        $collection->chunks->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $collection->insert($document);
+        unset($document['_id']);
+        $collection->chunks->insert($document);
 
         $collection->drop();
 
@@ -303,18 +305,5 @@ class MongoGridFSTest extends TestCase
         $extra += ['chunkSize' => 2];
 
         return $collection->storeBytes($data, $extra);
-    }
-
-    /**
-     * @return \MongoCollection
-     */
-    protected function prepareData()
-    {
-        $collection = $this->getGridFS();
-
-        $collection->insert(['foo' => 'bar']);
-        $collection->insert(['foo' => 'bar']);
-        $collection->insert(['foo' => 'foo']);
-        return $collection;
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/MongoUpdateBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoUpdateBatchTest.php
@@ -11,7 +11,8 @@ class MongoUpdateBatchTest extends TestCase
         $collection = $this->getCollection();
         $batch = new \MongoUpdateBatch($collection);
 
-        $collection->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $collection->insert($document);
 
         $this->assertTrue($batch->add(['q' => ['foo' => 'bar'], 'u' => ['$set' => ['foo' => 'foo']]]));
 
@@ -39,8 +40,10 @@ class MongoUpdateBatchTest extends TestCase
         $collection = $this->getCollection();
         $batch = new \MongoUpdateBatch($collection);
 
-        $collection->insert(['foo' => 'bar']);
-        $collection->insert(['foo' => 'bar']);
+        $document = ['foo' => 'bar'];
+        $collection->insert($document);
+        unset($document['_id']);
+        $collection->insert($document);
 
 
         $this->assertTrue($batch->add(['q' => ['foo' => 'bar'], 'u' => ['$set' => ['foo' => 'foo']], 'multi' => true]));

--- a/tests/Alcaeus/MongoDbAdapter/TestCase.php
+++ b/tests/Alcaeus/MongoDbAdapter/TestCase.php
@@ -76,4 +76,23 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
         return $database->getGridFS($prefix);
     }
+
+    /**
+     * @return \MongoCollection
+     */
+    protected function prepareData()
+    {
+        $collection = $this->getCollection();
+
+        $document = ['foo' => 'bar'];
+        $collection->insert($document);
+
+        unset($document['_id']);
+        $collection->insert($document);
+
+        $document = ['foo' => 'foo'];
+        $collection->insert($document);
+
+        return $collection;
+    }
 }


### PR DESCRIPTION
This changes to first argument (the object) to the `batchInsert`, `insert` and `save` methods in `MongoCollection` to be given by reference. While the original API doesn't specify them as by-reference parameters. It did however, add an `_id` property/field to the document if it was not already set. Since other libraries might rely on this functionality, the decision was made to provide that usecase instead of passing documents by value.