### PR TITLE
Removed provide configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ root:
 
     $ composer require "alcaeus/mongo-php-adapter=dev-master" "mongodb/mongodb=@beta"
 
-If your project includes a library that requires `ext-mongo` you need to also
-specify a `provide` option in your composer.json:
-    "provide": {
-        "ext-mongo": "1.6.12"
-    }
-
-Due to a limitation in composer you need to specify this in the root package.
-
 # Known issues
 
 ## Mongo


### PR DESCRIPTION
If I add this provide configuration I am unable to update composer as I am getting the following errors:

````
➜  project git:(php7) ✗ composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for my/project dev-php7 -> satisfiable by my/project[dev-php7].
    - don't install alcaeus/mongo-php-adapter dev-master|remove my/project dev-php7
    - Installation request for alcaeus/mongo-php-adapter dev-master -> satisfiable by alcaeus/mongo-php-adapter[dev-master].
````

If I remove the provide configuration everything works as expected. I am having doctrine-odm in the project which requires ext-mongo.