### PR TITLE
Run testsuite against ext-mongo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ addons:
 
 before_script:
   - pecl install -f mongodb-${DRIVER_VERSION}
-  - if [ "x$LEGACY_DRIVER_VERSION" != "x" ]; then yes '' | pecl -q install -f mongo-${LEGACY_DRIVER_VERSION}; fi
   - composer install
+  - if [ "x$LEGACY_DRIVER_VERSION" != "x" ]; then yes '' | pecl -q install -f mongo-${LEGACY_DRIVER_VERSION}; fi
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ php:
 
 env:
   matrix:
-    - DRIVER_VERSION=1.1.1
+    - DRIVER_VERSION=1.1.1 LEGACY_DRIVER_VERSION=""
+    - DRIVER_VERSION=1.1.1 LEGACY_DRIVER_VERSION=1.6.12
 
 addons:
   apt:
@@ -19,6 +20,7 @@ addons:
 
 before_script:
   - pecl install -f mongodb-${DRIVER_VERSION}
+  - if [ "x$LEGACY_DRIVER_VERSION" != "x" ]; then yes '' | pecl -q install -f mongo-${LEGACY_DRIVER_VERSION}; fi
   - composer install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ php:
   - 7.0
 
 env:
-  matrix:
-    - DRIVER_VERSION=1.1.1 LEGACY_DRIVER_VERSION=""
-    - DRIVER_VERSION=1.1.1 LEGACY_DRIVER_VERSION=1.6.12
+  - DRIVER_VERSION=1.1.1
+
+matrix:
+  include:
+    - php: 5.6
+      env: DRIVER_VERSION=1.1.1 LEGACY_DRIVER_VERSION=1.6.12
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -109,14 +109,22 @@ return `0` as connection ID.
  - The [hasNext](https://php.net/manual/en/mongocursor.hasnext.php)
  method is not yet implemented.
  - The [info](https://php.net/manual/en/mongocursor.info.php) method does not
- reliably fill all fields in the cursor information. This includes the `at`, `numReturned`,
- and `server` keys once the cursor has started iterating.
+ reliably fill all fields in the cursor information. This includes the `numReturned`
+ and `server` keys once the cursor has started iterating. The `numReturned` field
+ will always show the same value as the `at` field. The `server` field is lacking
+ authentication information.
  - The [setFlag](https://php.net/manual/en/mongocursor.setflag.php)
  method is not yet implemented.
 
 ## MongoCommandCursor
  - The [createFromDocument](https://php.net/manual/en/mongocommandcursor.createfromdocument.php)
  method is not yet implemented.
+ - The [info](https://php.net/manual/en/mongocommandcursor.info.php) method does not
+ reliably fill all fields in the cursor information. This includes the `at`, `numReturned`,
+ `firstBatchAt` and `firstBatchNumReturned` fields. The `at` and `numReturned`
+ fields always return 0 for compatibility to MongoCursor. The `firstBatchAt` and
+ `firstBatchNumReturned` fields will contain the same value, which is the internal
+ position of the iterator.
 
 ## Types
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ return `0` as connection ID.
 
 ## MongoCollection
 
+ - The [aggregate](https://secure.php.net/manual/en/mongocollection.aggregate.php)
+ method is not working because of a bug in the underlying library.
  - The [createIndex](https://secure.php.net/manual/en/mongocollection.createindex.php)
  method does not yet return the same result as the original method. Instead, it
  always returns the name of the index created.

--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -327,7 +327,7 @@ abstract class AbstractCursor
                 'id' => (string) $this->cursor->getId(),
                 'at' => null, // @todo Complete info for cursor that is iterating
                 'numReturned' => null, // @todo Complete info for cursor that is iterating
-                'server' => null, // @todo Complete info for cursor that is iterating
+                'server' => sprintf('%s:%d;-;.;%d', $this->cursor->getServer()->getHost(), $this->cursor->getServer()->getPort(), getmypid()),
                 'host' => $this->cursor->getServer()->getHost(),
                 'port' => $this->cursor->getServer()->getPort(),
                 'connection_type_desc' => $typeString,

--- a/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
@@ -28,7 +28,7 @@ class ExceptionConverter
      *
      * @return \MongoException
      */
-    public static function convertException(Exception\Exception $e, $fallbackClass = 'MongoException')
+    public static function toLegacy(Exception\Exception $e, $fallbackClass = 'MongoException')
     {
         switch (get_class($e)) {
             case Exception\AuthenticationException::class:
@@ -56,13 +56,5 @@ class ExceptionConverter
         }
 
         return new $class($e->getMessage(), $e->getCode(), $e);
-    }
-
-    /**
-     * @throws \MongoException
-     */
-    public static function toLegacy(Exception\Exception $e, $fallbackClass = 'MongoException')
-    {
-        throw self::convertException($e, $fallbackClass);
     }
 }

--- a/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
@@ -76,6 +76,10 @@ class ExceptionConverter
             return new \MongoConnectionException($message, $code, $e);
         }
 
+        if ($message === "cannot use 'w' > 1 when a host is not replicated") {
+            return new \MongoWriteConcernException($message, $code, $e);
+        }
+
         return new $class($message, $code, $e);
     }
 }

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -195,7 +195,7 @@ class MongoClient
         }
 
         foreach ($servers as $server) {
-            $key = sprintf('%s:%d', $server->getHost(), $server->getPort());
+            $key = sprintf('%s:%d;-;.;%d', $server->getHost(), $server->getPort(), getmypid());
             $info = $server->getInfo();
 
             switch ($server->getType()) {

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -256,7 +256,11 @@ class MongoClient
         ];
 
         foreach ($databaseInfoIterator as $databaseInfo) {
-            $databases['databases'][] = $databaseInfo->getName();
+            $databases['databases'][] = [
+                'name' => $databaseInfo->getName(),
+                'empty' => $databaseInfo->isEmpty(),
+                'sizeOnDisk' => $databaseInfo->getSizeOnDisk(),
+            ];
             $databases['totalSize'] += $databaseInfo->getSizeOnDisk();
         }
 

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -191,7 +191,7 @@ class MongoClient
         try {
             $servers = $this->manager->getServers();
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         foreach ($servers as $server) {
@@ -246,7 +246,7 @@ class MongoClient
         try {
             $databaseInfoIterator = $this->client->listDatabases();
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         $databases = [

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -181,7 +181,7 @@ class MongoCollection
 
         // Convert cursor option
         if (! isset($options['cursor'])) {
-            $options['cursor'] = true;
+            $options['cursor'] = new \stdClass();
         }
 
         $command += $options;

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -276,15 +276,6 @@ class MongoCollection
                 TypeConverter::fromLegacy($a),
                 $this->convertWriteConcernOptions($options)
             );
-        } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
-            $writeResult = $e->getWriteResult();
-            $writeError = $writeResult->getWriteErrors()[0];
-            return [
-                'ok' => 0.0,
-                'n' => 0,
-                'err' => $writeError->getCode(),
-                'errmsg' => $writeError->getMessage(),
-            ];
         } catch (\MongoDB\Driver\Exception\Exception $e) {
             throw ExceptionConverter::toLegacy($e);
         }
@@ -380,17 +371,6 @@ class MongoCollection
                 TypeConverter::fromLegacy($newobj),
                 $this->convertWriteConcernOptions($options)
             );
-        } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
-            $writeResult = $e->getWriteResult();
-            $writeError = $writeResult->getWriteErrors()[0];
-            return [
-                'ok' => 0.0,
-                'nModified' => $writeResult->getModifiedCount(),
-                'n' => $writeResult->getMatchedCount(),
-                'err' => $writeError->getCode(),
-                'errmsg' => $writeError->getMessage(),
-                'updatedExisting' => $writeResult->getUpsertedCount() == 0,
-            ];
         } catch (\MongoDB\Driver\Exception\Exception $e) {
             throw ExceptionConverter::toLegacy($e);
         }

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -263,7 +263,7 @@ class MongoCollection
     public function insert(&$a, array $options = [])
     {
         if (! $this->ensureDocumentHasMongoId($a)) {
-            trigger_error(sprintf('%s expects parameter %d to be an array or object, %s given', __METHOD__, 1, gettype($a)), E_USER_WARNING);
+            trigger_error(sprintf('%s(): expects parameter %d to be an array or object, %s given', __METHOD__, 1, gettype($a)), E_USER_WARNING);
             return;
         }
 
@@ -354,7 +354,6 @@ class MongoCollection
             'syncMillis' => 0,
             'writtenTo' => null,
             'err' => null,
-            'errmsg' => null,
         ];
     }
 
@@ -907,16 +906,13 @@ class MongoCollection
     {
         $checkKeys = function($array) {
             foreach (array_keys($array) as $key) {
-                if (is_int($key) || empty($key) || strpos($key, '*') === 1) {
+                if (empty($key) || strpos($key, '*') === 1) {
                     throw new \MongoException('document contain invalid key');
                 }
             }
         };
 
         if (is_array($document)) {
-            if (empty($document)) {
-                throw new \MongoException('document cannot be empty');
-            }
             if (! isset($document['_id'])) {
                 $document['_id'] = new \MongoId();
             }
@@ -925,9 +921,6 @@ class MongoCollection
 
             return $document['_id'];
         } elseif (is_object($document)) {
-            if (empty((array) $document)) {
-                throw new \MongoException('document cannot be empty');
-            }
             if (! isset($document->_id)) {
                 $document->_id = new \MongoId();
             }

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -286,7 +286,7 @@ class MongoCollection
                 'errmsg' => $writeError->getMessage(),
             ];
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         if (! $result->isAcknowledged()) {
@@ -341,7 +341,7 @@ class MongoCollection
                 $this->convertWriteConcernOptions($options)
             );
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         if (! $result->isAcknowledged()) {
@@ -393,7 +393,7 @@ class MongoCollection
                 'updatedExisting' => $writeResult->getUpsertedCount() == 0,
             ];
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         if (! $result->isAcknowledged()) {
@@ -433,7 +433,7 @@ class MongoCollection
                 $this->convertWriteConcernOptions($options)
             );
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         if (! $result->isAcknowledged()) {
@@ -513,7 +513,7 @@ class MongoCollection
         } catch (\MongoDB\Driver\Exception\ConnectionException $e) {
             throw new MongoResultException($e->getMessage(), $e->getCode(), $e);
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e, 'MongoResultException');
+            throw ExceptionConverter::toLegacy($e, 'MongoResultException');
         }
 
         if ($document) {
@@ -538,7 +538,7 @@ class MongoCollection
         try {
             $document = $this->collection->findOne(TypeConverter::fromLegacy($query), $options);
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         if ($document !== null) {
@@ -606,7 +606,7 @@ class MongoCollection
         try {
             $this->collection->createIndex($keys, $this->convertWriteConcernOptions($options));
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         return [
@@ -697,7 +697,7 @@ class MongoCollection
         try {
             return $this->collection->count(TypeConverter::fromLegacy($query), $options);
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
     }
 

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -492,7 +492,11 @@ class MongoCollection
 
                 $options['projection'] = is_array($fields) ? TypeConverter::fromLegacy($fields) : [];
 
-                $document = $this->collection->findOneAndUpdate($query, $update, $options);
+                if (! \MongoDB\is_first_key_operator($update)) {
+                    $document = $this->collection->findOneAndReplace($query, $update, $options);
+                } else {
+                    $document = $this->collection->findOneAndUpdate($query, $update, $options);
+                }
             }
         } catch (\MongoDB\Driver\Exception\ConnectionException $e) {
             throw new MongoResultException($e->getMessage(), $e->getCode(), $e);

--- a/lib/Mongo/MongoCommandCursor.php
+++ b/lib/Mongo/MongoCommandCursor.php
@@ -81,4 +81,23 @@ class MongoCommandCursor extends AbstractCursor implements MongoCursorInterface
             'fields' => null,
         ];
     }
+
+    /**
+     * @return array
+     */
+    protected function getIterationInfo()
+    {
+        $iterationInfo = parent::getIterationInfo();
+
+        if ($iterationInfo['started_iterating']) {
+            $iterationInfo += [
+                'firstBatchAt' => $iterationInfo['at'],
+                'firstBatchNumReturned' => $iterationInfo['numReturned'],
+            ];
+            $iterationInfo['at'] = 0;
+            $iterationInfo['numReturned'] = 0;
+        }
+
+        return $iterationInfo;
+    }
 }

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -146,7 +146,7 @@ class MongoCursor extends AbstractCursor implements Iterator
         } catch (\MongoDB\Driver\Exception\ExecutionTimeoutException $e) {
             throw new MongoCursorTimeoutException($e->getMessage(), $e->getCode(), $e);
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         return $count;
@@ -167,7 +167,7 @@ class MongoCursor extends AbstractCursor implements Iterator
         } catch (\MongoDB\Driver\Exception\ExecutionTimeoutException $e) {
             throw new MongoCursorTimeoutException($e->getMessage(), $e->getCode(), $e);
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
     }
 

--- a/lib/Mongo/MongoDB.php
+++ b/lib/Mongo/MongoDB.php
@@ -325,10 +325,10 @@ class MongoDB
             $id = $document_or_id;
         } elseif (is_object($document_or_id)) {
             if (! isset($document_or_id->_id)) {
-                return null;
+                $id = $document_or_id;
+            } else {
+                $id = $document_or_id->_id;
             }
-
-            $id = $document_or_id->_id;
         } elseif (is_array($document_or_id)) {
             if (! isset($document_or_id['_id'])) {
                 return null;
@@ -339,7 +339,7 @@ class MongoDB
             $id = $document_or_id;
         }
 
-        return MongoDBRef::create($collection, $id, $this->name);
+        return MongoDBRef::create($collection, $id);
     }
 
 

--- a/lib/Mongo/MongoDB.php
+++ b/lib/Mongo/MongoDB.php
@@ -134,7 +134,7 @@ class MongoDB
         try {
             $collections = $this->db->listCollections($options);
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         $getCollectionInfo = function (CollectionInfo $collectionInfo) {
@@ -164,7 +164,7 @@ class MongoDB
         try {
             $collections = $this->db->listCollections($options);
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            ExceptionConverter::toLegacy($e);
+            throw ExceptionConverter::toLegacy($e);
         }
 
         $getCollectionName = function (CollectionInfo $collectionInfo) {
@@ -388,8 +388,8 @@ class MongoDB
                 'errmsg' => $e->getMessage(),
                 'code' => $e->getCode(),
             ];
-        } catch (\MongoDB\Driver\Exception\Excepiton $e) {
-            ExceptionConverter::toLegacy($e);
+        } catch (\MongoDB\Driver\Exception\Exception $e) {
+            throw ExceptionConverter::toLegacy($e);
         }
     }
 

--- a/lib/Mongo/MongoDB.php
+++ b/lib/Mongo/MongoDB.php
@@ -112,8 +112,7 @@ class MongoDB
     public function __set($name, $value)
     {
         if ($name === 'w' || $name === 'wtimeout') {
-            $this->setWriteConcernFromArray([$name => $value] + $this->getWriteConcern());
-            $this->createDatabaseObject();
+            trigger_error("The '{$name}' property is read-only", E_DEPRECATED);
         }
     }
 
@@ -270,6 +269,10 @@ class MongoDB
     public function createCollection($name, $options)
     {
         try {
+            if (isset($options['capped'])) {
+                $options['capped'] = (bool) $options['capped'];
+            }
+
             $this->db->createCollection($name, $options);
         } catch (\MongoDB\Driver\Exception\Exception $e) {
             return false;
@@ -380,16 +383,12 @@ class MongoDB
             $cursor->setReadPreference($this->getReadPreference());
 
             return iterator_to_array($cursor)[0];
-        } catch (\MongoDB\Driver\Exception\ExecutionTimeoutException $e) {
-            throw new MongoCursorTimeoutException($e->getMessage(), $e->getCode(), $e);
-        } catch (\MongoDB\Driver\Exception\RuntimeException $e) {
+        } catch (\MongoDB\Driver\Exception\Exception $e) {
             return [
-                'ok' => 0,
+                'ok' => 0.0,
                 'errmsg' => $e->getMessage(),
                 'code' => $e->getCode(),
             ];
-        } catch (\MongoDB\Driver\Exception\Exception $e) {
-            throw ExceptionConverter::toLegacy($e);
         }
     }
 

--- a/lib/Mongo/MongoGridFS.php
+++ b/lib/Mongo/MongoGridFS.php
@@ -15,8 +15,6 @@
 
 class MongoGridFS extends MongoCollection
 {
-    const DEFAULT_CHUNK_SIZE = 262144; // 256 kb
-
     const ASCENDING = 1;
     const DESCENDING = -1;
 
@@ -44,6 +42,8 @@ class MongoGridFS extends MongoCollection
     private $database;
 
     private $prefix;
+
+    private $defaultChunkSize = 261120;
 
     /**
      * Files as stored across two collections, the first containing file meta
@@ -427,7 +427,7 @@ class MongoGridFS extends MongoCollection
         $record += [
             '_id' => new MongoId(),
             'uploadDate' => new MongoDate(),
-            'chunkSize' => self::DEFAULT_CHUNK_SIZE,
+            'chunkSize' => $this->defaultChunkSize,
         ];
 
         $result = $this->insert($record, $options);

--- a/lib/Mongo/MongoGridFS.php
+++ b/lib/Mongo/MongoGridFS.php
@@ -203,14 +203,14 @@ class MongoGridFS extends MongoCollection
         try {
             $file = $this->insertFile($record, $options);
         } catch (MongoException $e) {
-            throw new MongoGridFSException('Cannot insert file record', 0, $e);
+            throw new MongoGridFSException('Could not store file: '. $e->getMessage(), 0, $e);
         }
 
         try {
             $this->insertChunksFromBytes($bytes, $file);
         } catch (MongoException $e) {
             $this->delete($file['_id']);
-            throw new MongoGridFSException('Error while inserting chunks', 0, $e);
+            throw new MongoGridFSException('Could not store file: ' . $e->getMessage(), 0, $e);
         }
 
         return $file['_id'];
@@ -253,14 +253,14 @@ class MongoGridFS extends MongoCollection
         try {
             $file = $this->insertFile($record, $options);
         } catch (MongoException $e) {
-            throw new MongoGridFSException('Cannot insert file record', 0, $e);
+            throw new MongoGridFSException('Could not store file: ' . $e->getMessage(), 0, $e);
         }
 
         try {
             $length = $this->insertChunksFromFile($handle, $file, $md5);
         } catch (MongoException $e) {
             $this->delete($file['_id']);
-            throw new MongoGridFSException('Error while inserting chunks', 0, $e);
+            throw new MongoGridFSException('Could not store file: ' . $e->getMessage(), 0, $e);
         }
 
 
@@ -273,7 +273,7 @@ class MongoGridFS extends MongoCollection
             try {
                 $update['md5'] = $md5;
             } catch (MongoException $e) {
-                throw new MongoGridFSException('Error computing MD5 checksum', 0, $e);
+                throw new MongoGridFSException('Could not store file: ' . $e->getMessage(), 0, $e);
             }
         }
 
@@ -281,11 +281,11 @@ class MongoGridFS extends MongoCollection
             try {
                 $result = $this->update(['_id' => $file['_id']], ['$set' => $update]);
                 if (! $this->isOKResult($result)) {
-                    throw new MongoGridFSException('Error updating file record');
+                    throw new MongoGridFSException('Could not store file');
                 }
             } catch (MongoException $e) {
                 $this->delete($file['_id']);
-                throw new MongoGridFSException('Error updating file record', 0, $e);
+                throw new MongoGridFSException('Could not store file: ' . $e->getMessage(), 0, $e);
             }
 
         }

--- a/lib/Mongo/MongoWriteBatch.php
+++ b/lib/Mongo/MongoWriteBatch.php
@@ -115,38 +115,57 @@ class MongoWriteBatch
 
         try {
             $result = $collection->BulkWrite($this->items, $options);
-            $ok = 1.0;
+            $ok = true;
         } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
             $result = $e->getWriteResult();
-            $ok = 0.0;
+            $ok = false;
         }
 
-        if ($ok === 1.0) {
+        if ($ok === true) {
             $this->items = [];
         }
 
-        return [
-            'ok' => $ok,
-            'nInserted' => $result->getInsertedCount(),
-            'nMatched' => $result->getMatchedCount(),
-            'nModified' => $result->getModifiedCount(),
-            'nUpserted' => $result->getUpsertedCount(),
-            'nRemoved' => $result->getDeletedCount(),
-        ];
+        switch ($this->batchType) {
+            case self::COMMAND_UPDATE:
+                return [
+                    'nMatched' => $result->getMatchedCount(),
+                    'nModified' => $result->getModifiedCount(),
+                    'nUpserted' => $result->getUpsertedCount(),
+                    'ok' => $ok,
+                ];
+
+            case self::COMMAND_DELETE:
+                return [
+                    'nRemoved' => $result->getDeletedCount(),
+                    'ok' => $ok,
+                ];
+
+            case self::COMMAND_INSERT:
+                return [
+                    'nInserted' => $result->getInsertedCount(),
+                    'ok' => $ok,
+                ];
+        }
     }
 
     private function validate(array $item)
     {
         switch ($this->batchType) {
             case self::COMMAND_UPDATE:
-                if (! isset($item['q']) || ! isset($item['u'])) {
-                    throw new Exception('invalid item');
+                if (! isset($item['q'])) {
+                    throw new Exception("Expected $item to contain 'q' key");
+                }
+                if (! isset($item['u'])) {
+                    throw new Exception("Expected $item to contain 'u' key");
                 }
                 break;
 
             case self::COMMAND_DELETE:
-                if (! isset($item['q']) || ! isset($item['limit'])) {
-                    throw new Exception('invalid item');
+                if (! isset($item['q'])) {
+                    throw new Exception("Expected $item to contain 'q' key");
+                }
+                if (! isset($item['limit'])) {
+                    throw new Exception("Expected $item to contain 'limit' key");
                 }
                 break;
         }

--- a/lib/Mongo/MongoWriteBatch.php
+++ b/lib/Mongo/MongoWriteBatch.php
@@ -127,12 +127,26 @@ class MongoWriteBatch
 
         switch ($this->batchType) {
             case self::COMMAND_UPDATE:
-                return [
+                $upsertedIds = [];
+                foreach ($result->getUpsertedIds() as $index => $id) {
+                    $upsertedIds[] = [
+                        'index' => $index,
+                        '_id' => TypeConverter::toLegacy($id)
+                    ];
+                }
+
+                $result = [
                     'nMatched' => $result->getMatchedCount(),
                     'nModified' => $result->getModifiedCount(),
                     'nUpserted' => $result->getUpsertedCount(),
                     'ok' => $ok,
                 ];
+
+                if (count($upsertedIds)) {
+                    $result['upserted'] = $upsertedIds;
+                }
+
+                return $result;
 
             case self::COMMAND_DELETE:
                 return [
@@ -153,19 +167,19 @@ class MongoWriteBatch
         switch ($this->batchType) {
             case self::COMMAND_UPDATE:
                 if (! isset($item['q'])) {
-                    throw new Exception("Expected $item to contain 'q' key");
+                    throw new Exception("Expected \$item to contain 'q' key");
                 }
                 if (! isset($item['u'])) {
-                    throw new Exception("Expected $item to contain 'u' key");
+                    throw new Exception("Expected \$item to contain 'u' key");
                 }
                 break;
 
             case self::COMMAND_DELETE:
                 if (! isset($item['q'])) {
-                    throw new Exception("Expected $item to contain 'q' key");
+                    throw new Exception("Expected \$item to contain 'q' key");
                 }
                 if (! isset($item['limit'])) {
-                    throw new Exception("Expected $item to contain 'limit' key");
+                    throw new Exception("Expected \$item to contain 'limit' key");
                 }
                 break;
         }

--- a/lib/Mongo/functions.php
+++ b/lib/Mongo/functions.php
@@ -15,24 +15,28 @@
 
 use Alcaeus\MongoDbAdapter\TypeConverter;
 
-/**
- * Deserializes a BSON object into a PHP array
- *
- * @param string $bson The BSON to be deserialized.
- * @return array Returns the deserialized BSON object.
- */
-function bson_decode($bson)
-{
-    return TypeConverter::toLegacy(\MongoDB\BSON\toPHP($bson));
+if (! function_exists('bson_decode')) {
+    /**
+     * Deserializes a BSON object into a PHP array
+     *
+     * @param string $bson The BSON to be deserialized.
+     * @return array Returns the deserialized BSON object.
+     */
+    function bson_decode($bson)
+    {
+        return TypeConverter::toLegacy(\MongoDB\BSON\toPHP($bson));
+    }
 }
 
-/**
- * Serializes a PHP variable into a BSON string
- *
- * @param mixed $anything The variable to be serialized.
- * @return string Returns the serialized string.
- */
-function bson_encode($anything)
-{
-    return \MongoDB\BSON\fromPHP(TypeConverter::fromLegacy($anything));
+if (! function_exists('bson_encode')) {
+    /**
+     * Serializes a PHP variable into a BSON string
+     *
+     * @param mixed $anything The variable to be serialized.
+     * @return string Returns the serialized string.
+     */
+    function bson_encode($anything)
+    {
+        return \MongoDB\BSON\fromPHP(TypeConverter::fromLegacy($anything));
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,12 @@
          stopOnFailure="false"
          syntaxCheck="false"
 >
+    <php>
+        <!-- Disable deprecation warnings -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED & ~E_DEPRECATED;' -->
+        <ini name="error_reporting" value="-24577"/>
+    </php>
+
     <testsuites>
         <testsuite name="Mongo driver adapter test suite">
             <directory>./tests/Alcaeus/MongoDbAdapter/</directory>

--- a/tests/Alcaeus/MongoDbAdapter/ExceptionConverterTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/ExceptionConverterTest.php
@@ -7,18 +7,12 @@ use Alcaeus\MongoDbAdapter\ExceptionConverter;
 
 class ExceptionConverterTest extends \PHPUnit_Framework_TestCase
 {
-    public function testThrowException()
-    {
-        $this->setExpectedException('MongoException');
-        ExceptionConverter::toLegacy(new Exception\InvalidArgumentException());
-    }
-
     /**
      * @dataProvider exceptionProvider
      */
     public function testConvertException($e, $expectedClass)
     {
-        $exception = ExceptionConverter::convertException($e);
+        $exception = ExceptionConverter::toLegacy($e);
         $this->assertInstanceOf($expectedClass, $exception);
         $this->assertSame($e->getMessage(), $exception->getMessage());
         $this->assertSame($e->getCode(), $exception->getCode());

--- a/tests/Alcaeus/MongoDbAdapter/MongoBinDataTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoBinDataTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Alcaeus\MongoDbAdapter\Tests;
+use Alcaeus\MongoDbAdapter\TypeInterface;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -13,7 +14,17 @@ class MongoBinDataTest extends TestCase
         $this->assertAttributeSame('foo', 'bin', $bin);
         $this->assertAttributeSame(\MongoBinData::FUNC, 'type', $bin);
 
-        $this->assertSame('<Mongo Binary Data>', (string) $bin);
+        $this->assertSame('<Mongo Binary Data>', (string)$bin);
+
+        return $bin;
+    }
+
+    /**
+     * @depends testCreate
+     */
+    public function testConvertToBson(\MongoBinData $bin)
+    {
+        $this->skipTestUnless($bin instanceof TypeInterface);
 
         $bsonBinary = $bin->toBSONType();
         $this->assertInstanceOf('MongoDB\BSON\Binary', $bsonBinary);
@@ -24,6 +35,8 @@ class MongoBinDataTest extends TestCase
 
     public function testCreateWithBsonBinary()
     {
+        $this->skipTestUnless(in_array(TypeInterface::class, class_implements('MongoBinData')));
+
         $bsonBinary = new \MongoDB\BSON\Binary('foo', \MongoDB\BSON\Binary::TYPE_UUID);
         $bin = new \MongoBinData($bsonBinary);
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoClientTest.php
@@ -7,21 +7,6 @@ namespace Alcaeus\MongoDbAdapter\Tests;
  */
 class MongoClientTest extends TestCase
 {
-    public function testConnectAndDisconnect()
-    {
-        $client = $this->getClient();
-        $this->assertTrue($client->connected);
-
-        $client->close();
-        $this->assertFalse($client->connected);
-    }
-
-    public function testClientWithoutAutomaticConnect()
-    {
-        $client = $this->getClient([]);
-        $this->assertFalse($client->connected);
-    }
-
     public function testGetDb()
     {
         $client = $this->getClient();
@@ -63,16 +48,17 @@ class MongoClientTest extends TestCase
     public function testGetHosts()
     {
         $client = $this->getClient();
+        $hosts = $client->getHosts();
         $this->assertArraySubset(
             [
-                'localhost:27017' => [
+                'localhost:27017;-;.;' . getmypid() => [
                     'host' => 'localhost',
                     'port' => 27017,
                     'health' => 1,
                     'state' => 0,
                 ],
             ],
-            $client->getHosts()
+            $hosts
         );
     }
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoClientTest.php
@@ -67,8 +67,8 @@ class MongoClientTest extends TestCase
         $client = $this->getClient();
         $this->assertSame(['type' => \MongoClient::RP_PRIMARY], $client->getReadPreference());
 
-        $this->assertTrue($client->setReadPreference(\MongoClient::RP_SECONDARY, ['a' => 'b']));
-        $this->assertSame(['type' => \MongoClient::RP_SECONDARY, 'tagsets' => ['a' => 'b']], $client->getReadPreference());
+        $this->assertTrue($client->setReadPreference(\MongoClient::RP_SECONDARY, [['a' => 'b']]));
+        $this->assertSame(['type' => \MongoClient::RP_SECONDARY, 'tagsets' => [['a' => 'b']]], $client->getReadPreference());
     }
 
     public function testWriteConcern()

--- a/tests/Alcaeus/MongoDbAdapter/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoClientTest.php
@@ -74,7 +74,6 @@ class MongoClientTest extends TestCase
     public function testWriteConcern()
     {
         $client = $this->getClient();
-        $this->assertSame(['w' => 1, 'wtimeout' => 0], $client->getWriteConcern());
 
         $this->assertTrue($client->setWriteConcern('majority', 100));
         $this->assertSame(['w' => 'majority', 'wtimeout' => 100], $client->getWriteConcern());
@@ -89,7 +88,19 @@ class MongoClientTest extends TestCase
         $this->assertSame(1.0, $databases['ok']);
         $this->assertArrayHasKey('totalSize', $databases);
         $this->assertArrayHasKey('databases', $databases);
-        $this->assertContains('mongo-php-adapter', $databases['databases']);
+
+        foreach ($databases['databases'] as $database) {
+            $this->assertArrayHasKey('name', $database);
+            $this->assertArrayHasKey('empty', $database);
+            $this->assertArrayHasKey('sizeOnDisk', $database);
+
+            if ($database['name'] == 'mongo-php-adapter') {
+                $this->assertFalse($database['empty']);
+                return;
+            }
+        }
+
+        $this->fail('Could not find mongo-php-adapter database in list');
     }
 
     public function testNoPrefixUri()

--- a/tests/Alcaeus/MongoDbAdapter/MongoCodeTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCodeTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Alcaeus\MongoDbAdapter\Tests;
+use Alcaeus\MongoDbAdapter\TypeInterface;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -13,7 +14,17 @@ class MongoCodeTest extends TestCase
         $this->assertAttributeSame('code', 'code', $code);
         $this->assertAttributeSame(['scope' => 'bleh'], 'scope', $code);
 
-        $this->assertSame('code', (string) $code);
+        $this->assertSame('code', (string)$code);
+
+        return $code;
+    }
+
+    /**
+     * @depends testCreate
+     */
+    public function testConvertToBson(\MongoCode $code)
+    {
+        $this->skipTestUnless($code instanceof TypeInterface);
 
         $bsonCode = $code->toBSONType();
         $this->assertInstanceOf('MongoDB\BSON\Javascript', $bsonCode);
@@ -21,6 +32,8 @@ class MongoCodeTest extends TestCase
 
     public function testCreateWithBsonObject()
     {
+        $this->skipTestUnless(in_array(TypeInterface::class, class_implements('MongoCode')));
+
         $bsonCode = new \MongoDB\BSON\Javascript('code', ['scope' => 'bleh']);
         $code = new \MongoCode($bsonCode);
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -176,7 +176,7 @@ class MongoCollectionTest extends TestCase
 
     public function testBatchInsertException()
     {
-        $this->setExpectedException('MongoResultException', 'localhost:27017: cannot use \'w\' > 1 when a host is not replicated');
+        $this->setExpectedException('MongoResultException', 'cannot use \'w\' > 1 when a host is not replicated');
 
         $documents = [['foo' => 'bar']];
         $this->getCollection()->batchInsert($documents, ['w' => 2]);

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -105,7 +105,7 @@ class MongoCollectionTest extends TestCase
     {
         $this->setExpectedException(
             'MongoWriteConcernException',
-            "localhost:27017: cannot use 'w' > 1 when a host is not replicated"
+            "cannot use 'w' > 1 when a host is not replicated"
         );
 
         $document = ['foo' => 'bar'];
@@ -192,7 +192,7 @@ class MongoCollectionTest extends TestCase
 
     public function testUpdateWriteConcern()
     {
-        $this->setExpectedException('MongoWriteConcernException', "localhost:27017: cannot use 'w' > 1 when a host is not replicated");
+        $this->setExpectedException('MongoWriteConcernException', "cannot use 'w' > 1 when a host is not replicated");
 
         $this->getCollection()->update([], ['$set' => ['foo' => 'bar']], ['w' => 2]);
     }

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -221,7 +221,7 @@ class MongoCollectionTest extends TestCase
         $this->assertSame(1, $this->getCheckDatabase()->selectCollection('test')->count(['foo' => 'foo']));
     }
 
-    public function testUpdateFail()
+    public function testUpdateDuplicate()
     {
         $collection = $this->getCollection();
         $collection->createIndex(['foo' => 1], ['unique' => 1]);
@@ -641,19 +641,10 @@ class MongoCollectionTest extends TestCase
         $document = ['foo' => 'bar'];
         $collection->save($document);
 
-        $this->setExpectedException('MongoCursorException');
+        $this->setExpectedException('MongoDuplicateKeyException');
 
         unset($document['_id']);
-        $this->assertArraySubset(
-            [
-                'ok' => 0.0,
-                'nModified' => 0,
-                'n' => 0,
-                'err' => 11000,
-                'updatedExisting' => true,
-            ],
-            $collection->save($document)
-        );
+        $collection->save($document);
     }
 
     public function testSaveEmptyKeys()

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -494,7 +494,7 @@ class MongoCollectionTest extends TestCase
         $this->assertTrue($collection->getSlaveOkay());
 
         $this->assertTrue($collection->setSlaveOkay(true));
-        $this->assertSame(['type' => \MongoClient::RP_SECONDARY_PREFERRED, 'tagsets' => ['a' => 'b']], $collection->getReadPreference());
+        $this->assertSame(['type' => \MongoClient::RP_SECONDARY_PREFERRED, 'tagsets' => [['a' => 'b']]], $collection->getReadPreference());
 
         $this->assertTrue($collection->setSlaveOkay(false));
         $this->assertSame(['type' => \MongoClient::RP_PRIMARY], $collection->getReadPreference());
@@ -512,7 +512,7 @@ class MongoCollectionTest extends TestCase
         $readPreference = $collection->getCollection()->__debugInfo()['readPreference'];
 
         $this->assertSame(ReadPreference::RP_SECONDARY, $readPreference->getMode());
-        $this->assertSame(['a' => 'b'], $readPreference->getTagSets());
+        $this->assertSame([['a' => 'b']], $readPreference->getTagSets());
     }
 
     public function testReadPreferenceIsInherited()

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -877,6 +877,28 @@ class MongoCollectionTest extends TestCase
         $this->assertAttributeSame('foo', 'foo', $object);
     }
 
+    public function testFindAndModifyUpdateReplace()
+    {
+        $id = '54203e08d51d4a1f868b456e';
+        $collection = $this->getCollection();
+
+        $document = ['_id' => new \MongoId($id), 'foo' => 'bar'];
+        $collection->insert($document);
+        $document = $collection->findAndModify(
+            ['_id' => new \MongoId($id)],
+            ['_id' => new \MongoId($id), 'foo' => 'boo']
+        );
+        $this->assertSame('bar', $document['foo']);
+
+        $newCollection = $this->getCheckDatabase()->selectCollection('test');
+        $this->assertSame(1, $newCollection->count());
+        $object = $newCollection->findOne();
+
+        $this->assertNotNull($object);
+        $this->assertAttributeSame('boo', 'foo', $object);
+        $this->assertObjectNotHasAttribute('bar', $object);
+    }
+
     public function testFindAndModifyUpdateReturnNew()
     {
         $id = '54203e08d51d4a1f868b456e';

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -394,6 +394,7 @@ class MongoCollectionTest extends TestCase
 
     public function testAggregate()
     {
+        $this->skipTestUnless(extension_loaded('mongo'));
         $collection = $this->getCollection();
 
         $this->prepareData();
@@ -422,6 +423,7 @@ class MongoCollectionTest extends TestCase
 
     public function testAggregateTimeoutException()
     {
+        $this->skipTestUnless(extension_loaded('mongo'));
         $collection = $this->getCollection();
 
         $this->failMaxTimeMS();

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -91,7 +91,7 @@ class MongoCollectionTest extends TestCase
         $collection->insert($document);
 
         unset($document['_id']);
-        $this->setExpectedException('MongoDuplicateKeyException');
+        $this->setExpectedExceptionRegExp('MongoDuplicateKeyException', '/E11000 duplicate key error .* mongo-php-adapter\.test/');
         $collection->insert($document);
     }
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -176,10 +176,11 @@ class MongoCollectionTest extends TestCase
 
     public function testBatchInsertException()
     {
-        $this->setExpectedException('MongoResultException', 'cannot use \'w\' > 1 when a host is not replicated');
+        $this->setExpectedException('MongoDuplicateKeyException', 'E11000 duplicate key error index: mongo-php-adapter.test.$_id_');
 
-        $documents = [['foo' => 'bar']];
-        $this->getCollection()->batchInsert($documents, ['w' => 2]);
+        $id = new \MongoId();
+        $documents = [['_id' => $id, 'foo' => 'bar'], ['_id' => $id, 'foo' => 'bleh']];
+        $this->getCollection()->batchInsert($documents);
     }
 
     public function testBatchInsertEmptyBatchException()

--- a/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
@@ -42,7 +42,7 @@ class MongoCommandCursorTest extends TestCase
             'id' => '0',
             'at' => null,
             'numReturned' => null,
-            'server' => null,
+            'server' => 'localhost:27017;-;.;' . getmypid(),
             'host' => 'localhost',
             'port' => 27017,
             'connection_type_desc' => 'STANDALONE'

--- a/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
@@ -47,11 +47,9 @@ class MongoCommandCursorTest extends TestCase
             'host' => 'localhost',
             'port' => 27017,
             'connection_type_desc' => 'STANDALONE',
-            'firstBatchAt' => 2,
-            'firstBatchNumReturned' => 2,
         ];
 
-        $this->assertEquals($expected, $cursor->info());
+        $this->assertArraySubset($expected, $cursor->info());
 
         $i = 0;
         foreach ($array as $key => $value) {

--- a/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
@@ -17,7 +17,7 @@ class MongoCommandCursorTest extends TestCase
         $expected = [
             'ns' => 'mongo-php-adapter.test',
             'limit' => 0,
-            'batchSize' => null,
+            'batchSize' => 0,
             'skip' => 0,
             'flags' => 0,
             'query' => [
@@ -27,25 +27,28 @@ class MongoCommandCursorTest extends TestCase
                         '$match' => ['foo' => 'bar']
                     ]
                 ],
-                'cursor' => true,
+                'cursor' => new \stdClass(),
             ],
             'fields' => null,
             'started_iterating' => false,
         ];
-        $this->assertEquals($expected, $cursor->info());
+        $info = $cursor->info();
+        $this->assertEquals($expected, $info);
 
         // Ensure cursor started iterating
         $array = iterator_to_array($cursor);
 
         $expected['started_iterating'] = true;
         $expected += [
-            'id' => '0',
-            'at' => null,
-            'numReturned' => null,
+            'id' => 0,
+            'at' => 0,
+            'numReturned' => 0,
             'server' => 'localhost:27017;-;.;' . getmypid(),
             'host' => 'localhost',
             'port' => 27017,
-            'connection_type_desc' => 'STANDALONE'
+            'connection_type_desc' => 'STANDALONE',
+            'firstBatchAt' => 2,
+            'firstBatchNumReturned' => 2,
         ];
 
         $this->assertEquals($expected, $cursor->info());

--- a/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
@@ -42,7 +42,7 @@ class MongoCursorTest extends TestCase
 
     public function testCountCannotConnect()
     {
-        $client = $this->getClient([], 'mongodb://localhost:28888');
+        $client = $this->getClient(['connect' => false], 'mongodb://localhost:28888');
         $cursor = $client->selectCollection('mongo-php-adapter', 'test')->find();
 
         $this->setExpectedException('MongoConnectionException');
@@ -292,7 +292,7 @@ class MongoCursorTest extends TestCase
         $expected = [
             'ns' => 'mongo-php-adapter.test',
             'limit' => 3,
-            'batchSize' => null,
+            'batchSize' => 0,
             'skip' => 1,
             'flags' => 0,
             'query' => ['foo' => 'bar'],
@@ -300,23 +300,23 @@ class MongoCursorTest extends TestCase
             'started_iterating' => false,
         ];
 
-        $this->assertSame($expected, $cursor->info());
+        $this->assertEquals($expected, $cursor->info());
 
         // Ensure cursor started iterating
         iterator_to_array($cursor);
 
         $expected['started_iterating'] = true;
         $expected += [
-            'id' => '0',
-            'at' => null,
-            'numReturned' => null,
+            'id' => 0,
+            'at' => 1,
+            'numReturned' => 1,
             'server' => 'localhost:27017;-;.;' . getmypid(),
             'host' => 'localhost',
             'port' => 27017,
             'connection_type_desc' => 'STANDALONE'
         ];
 
-        $this->assertSame($expected, $cursor->info());
+        $this->assertEquals($expected, $cursor->info());
     }
 
     public function testReadPreferenceIsInherited()

--- a/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
@@ -310,7 +310,7 @@ class MongoCursorTest extends TestCase
             'id' => '0',
             'at' => null,
             'numReturned' => null,
-            'server' => null,
+            'server' => 'localhost:27017;-;.;' . getmypid(),
             'host' => 'localhost',
             'port' => 27017,
             'connection_type_desc' => 'STANDALONE'

--- a/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
@@ -90,6 +90,9 @@ class MongoCursorTest extends TestCase
         $collection = $this->getCollection();
         $cursor = $collection->find(['foo' => 'bar']);
 
+        $this->assertFalse($cursor->valid(), 'Cursor should be invalid to start with');
+
+        $cursor->next();
         $this->assertTrue($cursor->valid(), 'Cursor should be valid');
 
         $item = $cursor->current();

--- a/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
@@ -20,10 +20,11 @@ class MongoCursorTest extends TestCase
 
         $iterated = 0;
         foreach ($cursor as $key => $item) {
-            $iterated++;
+            $this->assertSame($iterated, $cursor->info()['at']);
             $this->assertInstanceOf('MongoId', $item['_id']);
             $this->assertEquals($key, (string) $item['_id']);
             $this->assertSame('bar', $item['foo']);
+            $iterated++;
         }
 
         $this->assertSame(2, $iterated);
@@ -91,6 +92,8 @@ class MongoCursorTest extends TestCase
         $cursor = $collection->find(['foo' => 'bar']);
 
         $this->assertFalse($cursor->valid(), 'Cursor should be invalid to start with');
+        $this->assertNull($cursor->current(), 'Cursor should be invalid to start with');
+        $this->assertNull($cursor->key(), 'Cursor should be invalid to start with');
 
         $cursor->next();
         $this->assertTrue($cursor->valid(), 'Cursor should be valid');

--- a/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
@@ -122,6 +122,8 @@ class MongoCursorTest extends TestCase
      */
     public function testCursorAppliesOptions($checkOptionCallback, \Closure $applyOptionCallback = null)
     {
+        $this->skipTestIf(extension_loaded('mongo'));
+
         $query = ['foo' => 'bar'];
         $projection = ['_id' => false, 'foo' => true];
 
@@ -320,10 +322,10 @@ class MongoCursorTest extends TestCase
     public function testReadPreferenceIsInherited()
     {
         $collection = $this->getCollection();
-        $collection->setReadPreference(\MongoClient::RP_SECONDARY, ['a' => 'b']);
+        $collection->setReadPreference(\MongoClient::RP_SECONDARY, [['a' => 'b']]);
 
         $cursor = $collection->find(['foo' => 'bar']);
-        $this->assertSame(['type' => \MongoClient::RP_SECONDARY, 'tagsets' => ['a' => 'b']], $cursor->getReadPreference());
+        $this->assertSame(['type' => \MongoClient::RP_SECONDARY, 'tagsets' => [['a' => 'b']]], $cursor->getReadPreference());
     }
 
     /**

--- a/tests/Alcaeus/MongoDbAdapter/MongoDBRefTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoDBRefTest.php
@@ -34,17 +34,18 @@ class MongoDBRefTest extends TestCase
     public static function dataCreateThroughMongoDB()
     {
         $id = new \MongoId();
-        $validRef = ['$ref' => 'test', '$id' => $id, '$db' => 'mongo-php-adapter'];
+        $validRef = ['$ref' => 'test', '$id' => $id];
 
         $object = new \stdClass();
         $object->_id = $id;
 
+        $objectWithoutId = new \stdClass();
         return [
             'simpleId' => [$validRef, $id],
             'arrayWithIdProperty' => [$validRef, ['_id' => $id]],
             'objectWithIdProperty' => [$validRef, $object],
             'arrayWithoutId' => [null, []],
-            'objectWithoutId' => [null, new \stdClass()],
+            'objectWithoutId' => [['$ref' => 'test', '$id' => $objectWithoutId], $objectWithoutId],
         ];
     }
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
@@ -144,7 +144,7 @@ class MongoDBTest extends TestCase
         $readPreference = $database->getDb()->__debugInfo()['readPreference'];
 
         $this->assertSame(ReadPreference::RP_SECONDARY, $readPreference->getMode());
-        $this->assertSame(['a' => 'b'], $readPreference->getTagSets());
+        $this->assertSame([['a' => 'b']], $readPreference->getTagSets());
 
     }
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoDBTest.php
@@ -71,7 +71,7 @@ class MongoDBTest extends TestCase
     {
         $database = $this->getDatabase();
 
-        $this->assertFalse($database->createCollection('test', ['capped' => 2, 'size' => 100]));
+        $this->assertInstanceOf('MongoCollection', $database->createCollection('test', ['capped' => 2, 'size' => 100]));
     }
 
     public function testGetCollectionProperty()
@@ -106,13 +106,17 @@ class MongoDBTest extends TestCase
 
         $this->failMaxTimeMS();
 
-        $this->setExpectedException('MongoCursorTimeoutException');
-
-        $database->command([
+        $result = $database->command([
             "count" => "test",
             "query" => array("a" => 1),
             "maxTimeMS" => 100,
         ]);
+
+        $this->assertSame([
+            'ok' => 0.0,
+            'errmsg' => 'operation exceeded time limit',
+            'code' => 50,
+        ], $result);
     }
 
     public function testReadPreference()
@@ -129,7 +133,8 @@ class MongoDBTest extends TestCase
         $this->assertSame(['type' => \MongoClient::RP_SECONDARY_PREFERRED, 'tagsets' => [['a' => 'b']]], $database->getReadPreference());
 
         $this->assertTrue($database->setSlaveOkay(false));
-        $this->assertSame(['type' => \MongoClient::RP_PRIMARY], $database->getReadPreference());
+        // Only test a subset since we don't keep tagsets around for RP_PRIMARY
+        $this->assertArraySubset(['type' => \MongoClient::RP_PRIMARY], $database->getReadPreference());
     }
 
     public function testReadPreferenceIsSetInDriver()
@@ -160,24 +165,9 @@ class MongoDBTest extends TestCase
     public function testWriteConcern()
     {
         $database = $this->getDatabase();
-        $this->assertSame(['w' => 1, 'wtimeout' => 0], $database->getWriteConcern());
-        $this->assertSame(1, $database->w);
-        $this->assertSame(0, $database->wtimeout);
 
         $this->assertTrue($database->setWriteConcern('majority', 100));
         $this->assertSame(['w' => 'majority', 'wtimeout' => 100], $database->getWriteConcern());
-
-        $database->w = 2;
-        $this->assertSame(['w' => 2, 'wtimeout' => 100], $database->getWriteConcern());
-
-        $database->wtimeout = -1;
-        $this->assertSame(['w' => 2, 'wtimeout' => 0], $database->getWriteConcern());
-
-        // Only way to check whether options are passed down is through debugInfo
-        $writeConcern = $database->getDb()->__debugInfo()['writeConcern'];
-
-        $this->assertSame(2, $writeConcern->getW());
-        $this->assertSame(0, $writeConcern->getWtimeout());
     }
 
     public function testWriteConcernIsSetInDriver()
@@ -197,10 +187,10 @@ class MongoDBTest extends TestCase
     public function testWriteConcernIsInherited()
     {
         $client = $this->getClient();
-        $client->setWriteConcern('majority', 100);
+        $client->setWriteConcern(2, 100);
 
         $database = $client->selectDB('test');
-        $this->assertSame(['w' => 'majority', 'wtimeout' => 100], $database->getWriteConcern());
+        $this->assertSame(['w' => 2, 'wtimeout' => 100], $database->getWriteConcern());
     }
 
     public function testProfilingLevel()
@@ -216,7 +206,7 @@ class MongoDBTest extends TestCase
     public function testForceError()
     {
         $result = $this->getDatabase()->forceError();
-        $this->assertSame(0, $result['ok']);
+        $this->assertSame(0.0, $result['ok']);
     }
 
     public function testExecute()

--- a/tests/Alcaeus/MongoDbAdapter/MongoDateTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoDateTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Alcaeus\MongoDbAdapter\Tests;
+use Alcaeus\MongoDbAdapter\TypeInterface;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -19,6 +20,18 @@ class MongoDateTest extends TestCase
         $this->assertSame(1234567890, $dateTime->getTimestamp());
         $this->assertSame('123000', $dateTime->format('u'));
 
+        return $date;
+    }
+
+    /**
+     * @depends testCreate
+     */
+    public function testConvertToBson(\MongoDate $date)
+    {
+        $this->skipTestUnless($date instanceof TypeInterface);
+
+        $dateTime = $date->toDateTime();
+
         $bsonDate = $date->toBSONType();
         $this->assertInstanceOf('MongoDB\BSON\UTCDateTime', $bsonDate);
         $this->assertSame('1234567890123', (string) $bsonDate);
@@ -28,6 +41,8 @@ class MongoDateTest extends TestCase
 
     public function testCreateWithBsonDate()
     {
+        $this->skipTestUnless(in_array(TypeInterface::class, class_implements('MongoDate')));
+
         $bsonDate = new \MongoDB\BSON\UTCDateTime(1234567890123);
         $date = new \MongoDate($bsonDate);
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoDeleteBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoDeleteBatchTest.php
@@ -17,12 +17,8 @@ class MongoDeleteBatchTest extends TestCase
         $this->assertTrue($batch->add(['q' => ['foo' => 'bar'], 'limit' => 1]));
 
         $expected = [
-            'ok' => 1.0,
-            'nInserted' => 0,
-            'nMatched' => 0,
-            'nModified' => 0,
-            'nUpserted' => 0,
             'nRemoved' => 1,
+            'ok' => true,
         ];
 
         $this->assertSame($expected, $batch->execute());
@@ -44,12 +40,8 @@ class MongoDeleteBatchTest extends TestCase
         $this->assertTrue($batch->add(['q' => ['foo' => 'bar'], 'limit' => 0]));
 
         $expected = [
-            'ok' => 1.0,
-            'nInserted' => 0,
-            'nMatched' => 0,
-            'nModified' => 0,
-            'nUpserted' => 0,
             'nRemoved' => 2,
+            'ok' => true,
         ];
 
         $this->assertSame($expected, $batch->execute());
@@ -64,7 +56,7 @@ class MongoDeleteBatchTest extends TestCase
         $collection = $this->getCollection();
         $batch = new \MongoDeleteBatch($collection);
 
-        $this->setExpectedException('Exception', 'invalid item');
+        $this->setExpectedException('Exception', "Expected \$item to contain 'q' key");
 
         $batch->add([]);
     }

--- a/tests/Alcaeus/MongoDbAdapter/MongoGridFSCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoGridFSCursorTest.php
@@ -19,7 +19,7 @@ class MongoGridFSCursorTest extends TestCase
 
             $this->assertArraySubset([
                 'filename' => 'foo.txt',
-                'chunkSize' => \MongoGridFS::DEFAULT_CHUNK_SIZE,
+                'chunkSize' => 261120,
                 'length' => 3,
                 'md5' => 'acbd18db4cc2f85cedef654fccc4a4d8'
             ], $value->file);

--- a/tests/Alcaeus/MongoDbAdapter/MongoGridFSFileTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoGridFSFileTest.php
@@ -32,10 +32,11 @@ class MongoGridFSFileTest extends TestCase
 
     public function testWrite()
     {
-        $id = $this->prepareFile();
         $filename = '/tmp/test-mongo-grid-fs-file';
+        $id = $this->prepareFile('abcd', ['filename' => $filename]);
         @unlink($filename);
-        $file = $this->getFile(['_id' => $id, 'length' => 4, 'filename' => $filename]);
+        $file = $this->getGridFS()->findOne(['_id' => $id]);
+        $this->assertInstanceOf(\MongoGridFSFile::class, $file);
 
         $file->write();
 
@@ -49,7 +50,8 @@ class MongoGridFSFileTest extends TestCase
         $id = $this->prepareFile();
         $filename = '/tmp/test-mongo-grid-fs-file';
         @unlink($filename);
-        $file = $this->getFile(['_id' => $id, 'length' => 4]);
+        $file = $this->getGridFS()->findOne(['_id' => $id]);
+        $this->assertInstanceOf(\MongoGridFSFile::class, $file);
 
         $file->write($filename);
 
@@ -70,13 +72,15 @@ class MongoGridFSFileTest extends TestCase
 
     public function testGetResource()
     {
-        $id = $this->prepareFile(str_repeat('a', 300 * 1024));
-        $file = $this->getFile(['_id' => $id, 'length' => 4]);
+        $data = str_repeat('a', 500 * 1024);
+        $id = $this->prepareFile($data);
+        $file = $this->getGridFS()->findOne(['_id' => $id]);
+        $this->assertInstanceOf(\MongoGridFSFile::class, $file);
 
         $result = $file->getResource();
 
         $this->assertTrue(is_resource($result));
-        $this->assertSame('abcd', stream_get_contents($result));
+        $this->assertSame($data, stream_get_contents($result));
     }
 
     /**

--- a/tests/Alcaeus/MongoDbAdapter/MongoGridFSFileTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoGridFSFileTest.php
@@ -70,7 +70,7 @@ class MongoGridFSFileTest extends TestCase
 
     public function testGetResource()
     {
-        $id = $this->prepareFile();
+        $id = $this->prepareFile(str_repeat('a', 300 * 1024));
         $file = $this->getFile(['_id' => $id, 'length' => 4]);
 
         $result = $file->getResource();
@@ -100,9 +100,6 @@ class MongoGridFSFileTest extends TestCase
     protected function prepareFile($data = 'abcd', $extra = [])
     {
         $collection = $this->getGridFS();
-
-        // to make sure we have multiple chunks
-        $extra += ['chunkSize' => 2];
 
         return $collection->storeBytes($data, $extra);
     }

--- a/tests/Alcaeus/MongoDbAdapter/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoGridFSTest.php
@@ -230,6 +230,7 @@ class MongoGridFSTest extends TestCase
 
     public function testStoreUpload()
     {
+        $this->skipTestIf(extension_loaded('mongo'));
         $collection = $this->getGridFS();
 
         $_FILES['foo'] = [
@@ -303,7 +304,7 @@ class MongoGridFSTest extends TestCase
         $document = ['_id' => $id];
         $collection->insert($document);
 
-        $this->setExpectedException('MongoGridFSException', 'Cannot insert file record');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
 
         $collection->storeBytes('foo', ['_id' => $id]);
     }
@@ -316,7 +317,7 @@ class MongoGridFSTest extends TestCase
         $document = ['n' => 0];
         $collection->chunks->insert($document);
 
-        $this->setExpectedException('MongoGridFSException', 'Error while inserting chunks');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
 
         $collection->storeBytes('foo');
     }
@@ -329,7 +330,7 @@ class MongoGridFSTest extends TestCase
         $document = ['_id' => $id];
         $collection->insert($document);
 
-        $this->setExpectedException('MongoGridFSException', 'Cannot insert file record');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
 
         $collection->storeFile(__FILE__, ['_id' => $id]);
     }
@@ -342,7 +343,7 @@ class MongoGridFSTest extends TestCase
         $document = ['n' => 0];
         $collection->chunks->insert($document);
 
-        $this->setExpectedException('MongoGridFSException', 'Error while inserting chunks');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
 
         $collection->storeFile(__FILE__);
     }
@@ -355,7 +356,7 @@ class MongoGridFSTest extends TestCase
         $document = ['length' => filesize(__FILE__)];
         $collection->insert($document);
 
-        $this->setExpectedException('MongoGridFSException', 'Error updating file record');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
 
         $collection->storeFile(fopen(__FILE__, 'r'));
     }

--- a/tests/Alcaeus/MongoDbAdapter/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoGridFSTest.php
@@ -304,7 +304,7 @@ class MongoGridFSTest extends TestCase
         $document = ['_id' => $id];
         $collection->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
 
         $collection->storeBytes('foo', ['_id' => $id]);
     }
@@ -317,7 +317,7 @@ class MongoGridFSTest extends TestCase
         $document = ['n' => 0];
         $collection->chunks->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
 
         $collection->storeBytes('foo');
     }
@@ -330,7 +330,7 @@ class MongoGridFSTest extends TestCase
         $document = ['_id' => $id];
         $collection->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
 
         $collection->storeFile(__FILE__, ['_id' => $id]);
     }
@@ -343,7 +343,7 @@ class MongoGridFSTest extends TestCase
         $document = ['n' => 0];
         $collection->chunks->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
 
         $collection->storeFile(__FILE__);
     }
@@ -356,7 +356,7 @@ class MongoGridFSTest extends TestCase
         $document = ['length' => filesize(__FILE__)];
         $collection->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file: localhost:27017: E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
 
         $collection->storeFile(fopen(__FILE__, 'r'));
     }

--- a/tests/Alcaeus/MongoDbAdapter/MongoIdTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoIdTest.php
@@ -43,8 +43,10 @@ class MongoIdTest extends TestCase
         new \MongoId('invalid');
     }
 
-    public function testCreateWithObjetId()
+    public function testCreateWithObjectId()
     {
+        $this->skipTestIf(extension_loaded('mongo'));
+
         $original = '54203e08d51d4a1f868b456e';
         $objectId = new \MongoDB\BSON\ObjectID($original);
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoIdTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoIdTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Alcaeus\MongoDbAdapter\Tests;
+use MongoDB\BSON\ObjectID;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -48,7 +49,7 @@ class MongoIdTest extends TestCase
         $this->skipTestIf(extension_loaded('mongo'));
 
         $original = '54203e08d51d4a1f868b456e';
-        $objectId = new \MongoDB\BSON\ObjectID($original);
+        $objectId = new ObjectID($original);
 
         $id = new \MongoId($objectId);
         $this->assertSame($original, (string) $id);
@@ -61,6 +62,7 @@ class MongoIdTest extends TestCase
      */
     public function testIsValid($expected, $value)
     {
+        $this->skipTestIf($value instanceof ObjectID && extension_loaded('mongo'));
         $this->assertSame($expected, \MongoId::isValid($value));
     }
 
@@ -71,7 +73,7 @@ class MongoIdTest extends TestCase
         return [
             'validId' => [true, '' . $original . ''],
             'MongoId' => [true, new \MongoId($original)],
-            'ObjectID' => [true, new \MongoDB\BSON\ObjectID($original)],
+            'ObjectID' => [true, new ObjectID($original)],
             'invalidString' => [false, 'abc'],
         ];
     }

--- a/tests/Alcaeus/MongoDbAdapter/MongoInsertBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoInsertBatchTest.php
@@ -40,7 +40,6 @@ class MongoInsertBatchTest extends TestCase
                 [
                     'index' => 1,
                     'code' => 11000,
-                    'errmsg' => 'E11000 duplicate key error collection: mongo-php-adapter.test index: foo_1 dup key: { : "bar" }',
                 ]
             ],
             'nInserted' => 1,
@@ -51,7 +50,7 @@ class MongoInsertBatchTest extends TestCase
             $batch->execute();
         } catch (\MongoWriteConcernException $e) {
             $this->assertSame('Failed write', $e->getMessage());
-            $this->assertSame($expected, $e->getDocument());
+            $this->assertArraySubset($expected, $e->getDocument());
         }
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/MongoMaxKeyTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoMaxKeyTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Alcaeus\MongoDbAdapter\Tests;
+use Alcaeus\MongoDbAdapter\TypeInterface;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -9,7 +10,8 @@ class MongoMaxKeyTest extends TestCase
 {
     public function testConvert()
     {
-        $MaxKey = new \MongoMaxKey();
-        $this->assertInstanceOf('MongoDB\BSON\MaxKey', $MaxKey->toBSONType());
+        $maxKey = new \MongoMaxKey();
+        $this->skipTestUnless($maxKey instanceof TypeInterface);
+        $this->assertInstanceOf('MongoDB\BSON\MaxKey', $maxKey->toBSONType());
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/MongoMinKeyTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoMinKeyTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Alcaeus\MongoDbAdapter\Tests;
+use Alcaeus\MongoDbAdapter\TypeInterface;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -10,6 +11,7 @@ class MongoMinKeyTest extends TestCase
     public function testConvert()
     {
         $minKey = new \MongoMinKey();
+        $this->skipTestUnless($minKey instanceof TypeInterface);
         $this->assertInstanceOf('MongoDB\BSON\MinKey', $minKey->toBSONType());
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/MongoRegexTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoRegexTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Alcaeus\MongoDbAdapter\Tests;
+use Alcaeus\MongoDbAdapter\TypeInterface;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -15,6 +16,16 @@ class MongoRegexTest extends TestCase
 
         $this->assertSame('/abc/i', (string) $regex);
 
+        return $regex;
+    }
+
+    /**
+     * @depends testCreate
+     */
+    public function testConvertToBson(\MongoRegex $regex)
+    {
+        $this->skipTestUnless($regex instanceof TypeInterface);
+
         $bsonRegex = $regex->toBSONType();
         $this->assertInstanceOf('MongoDB\BSON\Regex', $bsonRegex);
         $this->assertSame('abc', $bsonRegex->getPattern());
@@ -23,6 +34,8 @@ class MongoRegexTest extends TestCase
 
     public function testCreateWithBsonType()
     {
+        $this->skipTestUnless(in_array(TypeInterface::class, class_implements('MongoRegex')));
+
         $bsonRegex = new \MongoDB\BSON\Regex('abc', 'i');
         $regex = new \MongoRegex($bsonRegex);
 

--- a/tests/Alcaeus/MongoDbAdapter/MongoTimestampTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoTimestampTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Alcaeus\MongoDbAdapter\Tests;
+use Alcaeus\MongoDbAdapter\TypeInterface;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -14,6 +15,16 @@ class MongoTimestampTest extends TestCase
         $this->assertAttributeSame(987654321, 'inc', $timestamp);
 
         $this->assertSame('1234567890', (string) $timestamp);
+
+        return $timestamp;
+    }
+
+    /**
+     * @depends testCreate
+     */
+    public function testConvertToBson(\MongoTimestamp $timestamp)
+    {
+        $this->skipTestUnless($timestamp instanceof TypeInterface);
 
         $bsonTimestamp = $timestamp->toBSONType();
         $this->assertInstanceOf('MongoDB\BSON\Timestamp', $bsonTimestamp);
@@ -31,6 +42,8 @@ class MongoTimestampTest extends TestCase
 
     public function testCreateWithBsonTimestamp()
     {
+        $this->skipTestUnless(in_array(TypeInterface::class, class_implements('MongoTimestamp')));
+
         $bsonTimestamp = new \MongoDB\BSON\Timestamp(1234567890, 987654321);
         $timestamp = new \MongoTimestamp($bsonTimestamp);
 

--- a/tests/Alcaeus/MongoDbAdapter/TestCase.php
+++ b/tests/Alcaeus/MongoDbAdapter/TestCase.php
@@ -147,11 +147,19 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param $condition
+     * @param bool $condition
      */
     protected function skipTestUnless($condition)
     {
-        if (!$condition) {
+        $this->skipTestIf(! $condition);
+    }
+
+    /**
+     * @param bool $condition
+     */
+    protected function skipTestIf($condition)
+    {
+        if ($condition) {
             $this->markTestSkipped('Test only applies when running against mongo-php-adapter');
         }
     }

--- a/tests/Alcaeus/MongoDbAdapter/TestCase.php
+++ b/tests/Alcaeus/MongoDbAdapter/TestCase.php
@@ -145,4 +145,14 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     {
         return $this->configureFailPoint("maxTimeAlwaysTimeOut", array("times" => 1));
     }
+
+    /**
+     * @param $condition
+     */
+    protected function skipTestUnless($condition)
+    {
+        if (!$condition) {
+            $this->markTestSkipped('Test only applies when running against mongo-php-adapter');
+        }
+    }
 }


### PR DESCRIPTION
This PR adds ext-mongo to the build matrix in an effort to ensure the library behaves the same as ext-mongo does. This is achieved by running the tests with ext-mongo installed.

This PR will be used to stabilize the library before moving to a stable release.