### PR TITLE
Fix composer installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ root:
 
     $ composer require "alcaeus/mongo-php-adapter=dev-master" "mongodb/mongodb=@beta"
 
+If your project includes a library that requires `ext-mongo` you need to also
+specify a `provide` option in your composer.json:
+    "provide": {
+        "ext-mongo": "1.6.12"
+    }
+
+Due to a limitation in composer you need to specify this in the root package.
+
 # Known issues
 
 ## Mongo

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.0"
     },
-    "replace": {
+    "provide": {
         "ext-mongo": "1.6.12"
     },
     "autoload": {


### PR DESCRIPTION
Fixes #30.

From the tests run, using `provide` in this package and either `provide` or `replace` in the package using it (must be root level) seems to work consistently, so this is what it will be.