### PR TITLE
Compatibility improvements in MongoCollection and MongoCursor

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -62,6 +62,11 @@ abstract class AbstractCursor
     protected $ns;
 
     /**
+     * @var bool
+     */
+    protected $startedIterating = false;
+
+    /**
      * @var array
      */
     protected $optionNames = [
@@ -108,6 +113,7 @@ abstract class AbstractCursor
      */
     public function current()
     {
+        $this->startedIterating = true;
         $document = $this->ensureIterator()->current();
         if ($document !== null) {
             $document = TypeConverter::toLegacy($document);
@@ -127,15 +133,22 @@ abstract class AbstractCursor
     }
 
     /**
-     * Advances the cursor to the next result
+     * Advances the cursor to the next result, and returns that result
      * @link http://www.php.net/manual/en/mongocursor.next.php
      * @throws \MongoConnectionException
      * @throws \MongoCursorTimeoutException
-     * @return void
+     * @return array Returns the next object
      */
     public function next()
     {
-        $this->ensureIterator()->next();
+        if (!$this->startedIterating) {
+            $this->ensureIterator();
+            $this->startedIterating = true;
+        } else {
+            $this->ensureIterator()->next();
+        }
+
+        return $this->current();
     }
 
     /**
@@ -148,6 +161,7 @@ abstract class AbstractCursor
     {
         // We can recreate the cursor to allow it to be rewound
         $this->reset();
+        $this->startedIterating = true;
         $this->ensureIterator()->rewind();
     }
 
@@ -338,6 +352,7 @@ abstract class AbstractCursor
      */
     protected function reset()
     {
+        $this->startedIterating = false;
         $this->cursor = null;
         $this->iterator = null;
     }

--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -280,6 +280,12 @@ abstract class AbstractCursor
     private function wrapTraversable(\Traversable $traversable)
     {
         foreach ($traversable as $key => $value) {
+            if ($this instanceof \MongoCursor &&
+                isset($value->_id) &&
+                ($value->_id instanceof \MongoDB\BSON\ObjectID || !is_object($value->_id))
+            ) {
+                $key = (string) $value->_id;
+            }
             yield $key => $value;
         }
     }

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -197,7 +197,7 @@ class MongoCursor extends AbstractCursor implements Iterator
     }
 
     /**
-     * Return the next object to which this cursor points, and advance the cursor
+     * Advances the cursor to the next result, and returns that result
      * @link http://www.php.net/manual/en/mongocursor.getnext.php
      * @throws MongoConnectionException
      * @throws MongoCursorTimeoutException
@@ -205,9 +205,7 @@ class MongoCursor extends AbstractCursor implements Iterator
      */
     public function getNext()
     {
-        $this->next();
-
-        return $this->current();
+        return $this->next();
     }
 
     /**

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -618,6 +618,24 @@ class MongoCollectionTest extends TestCase
         $this->assertAttributeSame('foo', 'foo', $object);
     }
 
+    public function testSavingShouldReplaceTheWholeDocument() {
+        $id = '54203e08d51d4a1f868b456e';
+        $collection = $this->getCollection();
+
+        $insertDocument = ['_id' => new \MongoId($id), 'foo' => 'bar'];
+        $saveDocument = ['_id' => new \MongoId($id)];
+
+        $collection->insert($insertDocument);
+        $collection->save($saveDocument);
+
+        $newCollection = $this->getCheckDatabase()->selectCollection('test');
+        $this->assertSame(1, $newCollection->count());
+        $object = $newCollection->findOne();
+
+        $this->assertNotNull($object);
+        $this->assertObjectNotHasAttribute('foo', $object);
+    }
+
     public function testSaveDuplicate()
     {
         $collection = $this->getCollection();

--- a/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
@@ -35,7 +35,7 @@ class MongoCommandCursorTest extends TestCase
         $this->assertEquals($expected, $cursor->info());
 
         // Ensure cursor started iterating
-        iterator_to_array($cursor);
+        $array = iterator_to_array($cursor);
 
         $expected['started_iterating'] = true;
         $expected += [
@@ -49,5 +49,11 @@ class MongoCommandCursorTest extends TestCase
         ];
 
         $this->assertEquals($expected, $cursor->info());
+
+        $i = 0;
+        foreach ($array as $key => $value) {
+            $this->assertEquals($i, $key);
+            $i++;
+        }
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
@@ -49,6 +49,39 @@ class MongoCursorTest extends TestCase
         $cursor->count();
     }
 
+    public function testNextStartsWithFirstItem()
+    {
+        $this->prepareData();
+
+        $collection = $this->getCollection();
+        $cursor = $collection->find(['foo' => 'bar']);
+
+        $item = $cursor->getNext();
+        $this->assertNotNull($item);
+        $this->assertInstanceOf('MongoId', $item['_id']);
+        $this->assertSame('bar', $item['foo']);
+
+        $item = $cursor->getNext();
+        $this->assertNotNull($item);
+        $this->assertInstanceOf('MongoId', $item['_id']);
+        $this->assertSame('bar', $item['foo']);
+
+        $item = $cursor->getNext();
+        $this->assertNull($item);
+
+        $cursor->reset();
+
+        $item = $cursor->getNext();
+        $this->assertNotNull($item);
+        $this->assertInstanceOf('MongoId', $item['_id']);
+        $this->assertSame('bar', $item['foo']);
+
+        $item = $cursor->getNext();
+        $this->assertNotNull($item);
+        $this->assertInstanceOf('MongoId', $item['_id']);
+        $this->assertSame('bar', $item['foo']);
+    }
+
     public function testIteratorInterface()
     {
         $this->prepareData();

--- a/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
@@ -19,9 +19,10 @@ class MongoCursorTest extends TestCase
         $this->assertCount(2, $cursor);
 
         $iterated = 0;
-        foreach ($cursor as $item) {
+        foreach ($cursor as $key => $item) {
             $iterated++;
             $this->assertInstanceOf('MongoId', $item['_id']);
+            $this->assertEquals($key, (string) $item['_id']);
             $this->assertSame('bar', $item['foo']);
         }
 


### PR DESCRIPTION
Because of backwards compatibility reasons MongoCursor's implementation of next/getNext is a bit strange and does not match the implementations of "normal" iterators:

* getNext is an alias for next
* On the first call, when the cursor has not been used yet, next returns current
* On all subsequent calls next advances the cursor and then returns current

See https://github.com/mongodb/mongo-php-driver-legacy/blob/master/cursor.c#L963

--

MongoCursor should use _id of document as key if present

See https://github.com/mongodb/mongo-php-driver-legacy/blob/master/cursor.c#L946

--

MongoCollection::save should replace the whole document instead of only setting the given fields

Doing an update with $set will not remove fields, that are not present in the new document anymore.