### PR TITLE
Correctly throw MongoDuplicateKeyExceptions

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
@@ -30,6 +30,9 @@ class ExceptionConverter
      */
     public static function convertException(Exception\Exception $e, $fallbackClass = 'MongoException')
     {
+        $message = $e->getMessage();
+        $code = $e->getCode();
+
         switch (get_class($e)) {
             case Exception\AuthenticationException::class:
             case Exception\ConnectionException::class:
@@ -40,7 +43,25 @@ class ExceptionConverter
 
             case Exception\BulkWriteException::class:
             case Exception\WriteException::class:
-                $class = 'MongoCursorException';
+                $writeResult = $e->getWriteResult();
+
+                if ($writeResult) {
+                    $writeError = $writeResult->getWriteErrors()[0];
+
+                    $message = $writeError->getMessage();
+                    $code = $writeError->getCode();
+                }
+
+                switch ($code) {
+                    // see https://github.com/mongodb/mongo-php-driver-legacy/blob/ad3ed45739e9702ae48e53ddfadc482d9c4c7e1c/cursor_shared.c#L540
+                    case 11000:
+                    case 11001:
+                    case 12582:
+                        $class = 'MongoDuplicateKeyException';
+                        break;
+                    default:
+                        $class = 'MongoCursorException';
+                }
                 break;
 
             case Exception\ExecutionTimeoutException::class:
@@ -51,11 +72,11 @@ class ExceptionConverter
                 $class = $fallbackClass;
         }
 
-        if (strpos($e->getMessage(), 'No suitable servers found') !== false) {
-            return new \MongoConnectionException($e->getMessage(), $e->getCode(), $e);
+        if (strpos($message, 'No suitable servers found') !== false) {
+            return new \MongoConnectionException($message, $code, $e);
         }
 
-        return new $class($e->getMessage(), $e->getCode(), $e);
+        return new $class($message, $code, $e);
     }
 
     /**

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -277,15 +277,6 @@ class MongoCollection
                 TypeConverter::fromLegacy($a),
                 $this->convertWriteConcernOptions($options)
             );
-        } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
-            $writeResult = $e->getWriteResult();
-            $writeError = $writeResult->getWriteErrors()[0];
-            return [
-                'ok' => 0.0,
-                'n' => 0,
-                'err' => $writeError->getCode(),
-                'errmsg' => $writeError->getMessage(),
-            ];
         } catch (\MongoDB\Driver\Exception\Exception $e) {
             ExceptionConverter::toLegacy($e);
         }
@@ -382,17 +373,6 @@ class MongoCollection
                 TypeConverter::fromLegacy($newobj),
                 $this->convertWriteConcernOptions($options)
             );
-        } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
-            $writeResult = $e->getWriteResult();
-            $writeError = $writeResult->getWriteErrors()[0];
-            return [
-                'ok' => 0.0,
-                'nModified' => $writeResult->getModifiedCount(),
-                'n' => $writeResult->getMatchedCount(),
-                'err' => $writeError->getCode(),
-                'errmsg' => $writeError->getMessage(),
-                'updatedExisting' => $writeResult->getUpsertedCount() == 0,
-            ];
         } catch (\MongoDB\Driver\Exception\Exception $e) {
             ExceptionConverter::toLegacy($e);
         }

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -90,15 +90,10 @@ class MongoCollectionTest extends TestCase
         $document = ['foo' => 'bar'];
         $collection->insert($document);
 
+        $this->setExpectedException('MongoDuplicateKeyException');
+
         unset($document['_id']);
-        $this->assertArraySubset(
-            [
-                'ok' => 0.0,
-                'n' => 0,
-                'err' => 11000,
-            ],
-            $collection->insert($document)
-        );
+        $collection->insert($document);
     }
 
     public function testUnacknowledgedWrite()
@@ -227,7 +222,7 @@ class MongoCollectionTest extends TestCase
         $this->assertSame(1, $this->getCheckDatabase()->selectCollection('test')->count(['foo' => 'foo']));
     }
 
-    public function testUpdateFail()
+    public function testUpdateDuplicate()
     {
         $collection = $this->getCollection();
         $collection->createIndex(['foo' => 1], ['unique' => 1]);
@@ -237,16 +232,9 @@ class MongoCollectionTest extends TestCase
         $document = ['foo' => 'foo'];
         $collection->insert($document);
 
-        $this->assertArraySubset(
-            [
-                'ok' => 0.0,
-                'nModified' => 0,
-                'n' => 0,
-                'err' => 11000,
-                'updatedExisting' => true,
-            ],
-            $collection->update(['foo' => 'bar'], ['$set' => ['foo' => 'foo']])
-        );
+        $this->setExpectedException('MongoDuplicateKeyException');
+
+        $collection->update(['foo' => 'bar'], ['$set' => ['foo' => 'foo']]);
     }
 
     public function testUpdateMany()
@@ -627,19 +615,10 @@ class MongoCollectionTest extends TestCase
         $document = ['foo' => 'bar'];
         $collection->save($document);
 
-        $this->setExpectedException('MongoCursorException');
+        $this->setExpectedException('MongoDuplicateKeyException');
 
         unset($document['_id']);
-        $this->assertArraySubset(
-            [
-                'ok' => 0.0,
-                'nModified' => 0,
-                'n' => 0,
-                'err' => 11000,
-                'updatedExisting' => true,
-            ],
-            $collection->save($document)
-        );
+        $collection->save($document);
     }
 
     public function testSaveEmptyKeys()


### PR DESCRIPTION
First attempt to correctly throw MongoDuplicateKeyExceptions

The thing I'm not sure about if it is ok to delete this catch block in MongoCollection

```
        } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {		
            $writeResult = $e->getWriteResult();		
            $writeError = $writeResult->getWriteErrors()[0];		
            return [		
                'ok' => 0.0,		
                'n' => 0,		
                'err' => $writeError->getCode(),		
                'errmsg' => $writeError->getMessage(),		
            ];
```

Are there any cases where a BulkWriteException is thrown and we have to return and not just throw the corresponding exception from ext-mongo?