### PR TITLE
Fix: MongoCollection::save should replace the whole document

### DIFF
--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -618,6 +618,24 @@ class MongoCollectionTest extends TestCase
         $this->assertAttributeSame('foo', 'foo', $object);
     }
 
+    public function testSavingShouldReplaceTheWholeDocument() {
+        $id = '54203e08d51d4a1f868b456e';
+        $collection = $this->getCollection();
+
+        $insertDocument = ['_id' => new \MongoId($id), 'foo' => 'bar'];
+        $saveDocument = ['_id' => new \MongoId($id)];
+
+        $collection->insert($insertDocument);
+        $collection->save($saveDocument);
+
+        $newCollection = $this->getCheckDatabase()->selectCollection('test');
+        $this->assertSame(1, $newCollection->count());
+        $object = $newCollection->findOne();
+
+        $this->assertNotNull($object);
+        $this->assertObjectNotHasAttribute('foo', $object);
+    }
+
     public function testSaveDuplicate()
     {
         $collection = $this->getCollection();


### PR DESCRIPTION
Fix: MongoCollection::save should replace the whole document instead of only setting the given fields

Doing an update with $set will not remove fields, that are not present in the new document anymore.

See http://php.net/manual/en/mongocollection.save.php

Replaces https://github.com/alcaeus/mongo-php-adapter/pull/35 which contained multiple commits for different issues