### PR TITLE
Fix: MongoCursor uses _id as key if present

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -263,7 +263,7 @@ abstract class AbstractCursor
      * @param \Traversable $traversable
      * @return \Generator
      */
-    private function wrapTraversable(\Traversable $traversable)
+    protected function wrapTraversable(\Traversable $traversable)
     {
         foreach ($traversable as $key => $value) {
             yield $key => $value;

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -429,6 +429,20 @@ class MongoCursor extends AbstractCursor implements Iterator
     }
 
     /**
+     * @param \Traversable $traversable
+     * @return \Generator
+     */
+    protected function wrapTraversable(\Traversable $traversable)
+    {
+        foreach ($traversable as $key => $value) {
+            if (isset($value->_id) && ($value->_id instanceof \MongoDB\BSON\ObjectID || !is_object($value->_id))) {
+                $key = (string) $value->_id;
+            }
+            yield $key => $value;
+        }
+    }
+
+    /**
      * @return array
      */
     protected function getCursorInfo()

--- a/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCommandCursorTest.php
@@ -35,7 +35,7 @@ class MongoCommandCursorTest extends TestCase
         $this->assertEquals($expected, $cursor->info());
 
         // Ensure cursor started iterating
-        iterator_to_array($cursor);
+        $array = iterator_to_array($cursor);
 
         $expected['started_iterating'] = true;
         $expected += [
@@ -49,5 +49,11 @@ class MongoCommandCursorTest extends TestCase
         ];
 
         $this->assertEquals($expected, $cursor->info());
+
+        $i = 0;
+        foreach ($array as $key => $value) {
+            $this->assertEquals($i, $key);
+            $i++;
+        }
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCursorTest.php
@@ -19,9 +19,10 @@ class MongoCursorTest extends TestCase
         $this->assertCount(2, $cursor);
 
         $iterated = 0;
-        foreach ($cursor as $item) {
+        foreach ($cursor as $key => $item) {
             $iterated++;
             $this->assertInstanceOf('MongoId', $item['_id']);
+            $this->assertEquals($key, (string) $item['_id']);
             $this->assertSame('bar', $item['foo']);
         }
 


### PR DESCRIPTION
See https://github.com/mongodb/mongo-php-driver-legacy/blob/master/cursor.c#L946

Replaces https://github.com/alcaeus/mongo-php-adapter/pull/35 which contained multiple commits for different issues