### PR TITLE
Default to '' all update data in findAndModify if  doesn't contain a key operator

### DIFF
--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -501,6 +501,10 @@ class MongoCollection
             } else {
                 $update = is_array($update) ? TypeConverter::fromLegacy($update) : [];
 
+                if (!\MongoDB\is_first_key_operator($update)) {
+                    $update = ['$set' => $update];
+                }
+
                 if (isset($options['new'])) {
                     $options['returnDocument'] = \MongoDB\Operation\FindOneAndUpdate::RETURN_DOCUMENT_AFTER;
                     unset($options['new']);

--- a/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/MongoCollectionTest.php
@@ -875,6 +875,27 @@ class MongoCollectionTest extends TestCase
         $this->assertAttributeSame('foo', 'foo', $object);
     }
 
+    public function testFindAndModifyUpdateDocument()
+    {
+        $id = '54203e08d51d4a1f868b456e';
+        $collection = $this->getCollection();
+
+        $document = ['_id' => new \MongoId($id), 'foo' => 'bar'];
+        $collection->insert($document);
+        $document = $collection->findAndModify(
+            ['_id' => new \MongoId($id)],
+            ['_id' => new \MongoId($id), 'foo' => 'boo']
+        );
+        $this->assertSame('bar', $document['foo']);
+
+        $newCollection = $this->getCheckDatabase()->selectCollection('test');
+        $this->assertSame(1, $newCollection->count());
+        $object = $newCollection->findOne();
+
+        $this->assertNotNull($object);
+        $this->assertAttributeSame('boo', 'foo', $object);
+    }
+
     public function testFindAndModifyUpdateReturnNew()
     {
         $id = '54203e08d51d4a1f868b456e';


### PR DESCRIPTION
If the $update map for findAndUpdate does not contain an operator (for example '$set'), the expected behaviour is to treat it like ['$set' => $update]

Not sure if this is actually documented, but I do have to deal with code that uses this "feature" quite a bit...