### PR TITLE
Implement includeSystemCollections behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,6 @@ return `0` as connection ID.
  - The [authenticate](https://secure.php.net/manual/en/mongodb.authenticate.php)
  method is not supported. To connect to a database with authentication, please
  supply the credentials using the connection string.
- - The `includeSystemCollections` parameter used in the [getCollectionInfo](https://php.net/manual/en/mongodb.getcollectioninfo.php]),
- [getCollectionNames](https://php.net/manual/en/mongodb.getcollectionnames.php]),
- and [listCollections](https://php.net/manual/en/mongodb.listcollections.php)
- methods is ignored. These methods do not return information about system
- collections.
 
 ## MongoCollection
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
@@ -283,6 +283,38 @@ class MongoDBTest extends TestCase
         $this->fail('The test collection was not found');
     }
 
+    public function testGetCollectionNamesDoesNotListSystemCollections()
+    {
+        // Enable profiling to ensure we have a system.profile collection
+        $this->getDatabase()->setProfilingLevel(\MongoDB::PROFILING_ON);
+
+        try {
+            $document = ['foo' => 'bar'];
+            $this->getCollection()->insert($document);
+
+            $collectionNames = $this->getDatabase()->getCollectionNames();
+            $this->assertNotContains('system.profile', $collectionNames);
+        } finally {
+            $this->getDatabase()->setProfilingLevel(\MongoDB::PROFILING_OFF);
+        }
+    }
+
+    public function testGetCollectionNamesWithSystemCollections()
+    {
+        // Enable profiling to ensure we have a system.profile collection
+        $this->getDatabase()->setProfilingLevel(\MongoDB::PROFILING_ON);
+
+        try {
+            $document = ['foo' => 'bar'];
+            $this->getCollection()->insert($document);
+
+            $collectionNames = $this->getDatabase()->getCollectionNames(['includeSystemCollections' => true]);
+            $this->assertContains('system.profile', $collectionNames);
+        } finally {
+            $this->getDatabase()->setProfilingLevel(\MongoDB::PROFILING_OFF);
+        }
+    }
+
     public function testListCollectionsExecutionTimeoutException()
     {
         $this->failMaxTimeMS();


### PR DESCRIPTION
This implements `includeSystemCollections` functionality in MongoDB::getCollectionInfo() and MongoDB::getCollectionNames(). Any collection starting with `system.` is ignored unless the option is set to true.