### PR TITLE
Ensure no MongoDB driver classes are serialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ counterparts in `ext-mongo`. Do not rely on exception messages being the same.
 Methods that return a result array containing a `connectionId` field will always
 return `0` as connection ID.
 
+## Serialization of objects
+Serialization of any Mongo* objects (e.g. MongoGridFSFile, MongoCursor, etc.)
+will not work properly. The objects can be serialized but are not usable after
+unserializing them.
+
 ## Mongo
 
  - The Mongo class is deprecated and was not implemented in this library. If you

--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -375,4 +375,12 @@ abstract class AbstractCursor
         $this->cursor = null;
         $this->iterator = null;
     }
+
+    /**
+     * @return array
+     */
+    public function __sleep()
+    {
+        return ['batchSize', 'connection', 'iterator', 'ns', 'optionNames', 'position', 'startedIterating'];
+    }
 }

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -334,5 +334,15 @@ class MongoClient
     {
         throw new \Exception('Not implemented');
     }
+
+    /**
+     * @return array
+     */
+    function __sleep()
+    {
+        return [
+            'connected', 'status', 'server', 'persistent'
+        ];
+    }
 }
 

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -958,5 +958,13 @@ class MongoCollection
             throw new Exception('Collection name cannot contain null bytes');
         }
     }
+
+    /**
+     * @return array
+     */
+    public function __sleep()
+    {
+        return ['db', 'name'];
+    }
 }
 

--- a/lib/Mongo/MongoCommandCursor.php
+++ b/lib/Mongo/MongoCommandCursor.php
@@ -100,4 +100,12 @@ class MongoCommandCursor extends AbstractCursor implements MongoCursorInterface
 
         return $iterationInfo;
     }
+
+    /**
+     * @return array
+     */
+    public function __sleep()
+    {
+        return ['command'] + parent::__sleep();
+    }
 }

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -455,4 +455,28 @@ class MongoCursor extends AbstractCursor implements Iterator
             'fields' => $this->projection,
         ];
     }
+
+    /**
+     * @return array
+     */
+    public function __sleep()
+    {
+        return [
+            'allowPartialResults',
+            'awaitData',
+            'flags',
+            'hint',
+            'limit',
+            'maxTimeMS',
+            'noCursorTimeout',
+            'optionNames',
+            'options',
+            'projection',
+            'query',
+            'skip',
+            'snapshot',
+            'sort',
+            'tailable',
+        ] + parent::__sleep();
+    }
 }

--- a/lib/Mongo/MongoDB.php
+++ b/lib/Mongo/MongoDB.php
@@ -541,4 +541,12 @@ class MongoDB
             return $includeSystemCollections || ! preg_match('#^system\.#', $collectionInfo->getName());
         };
     }
+
+    /**
+     * @return array
+     */
+    public function __sleep()
+    {
+        return ['connection', 'name'];
+    }
 }

--- a/lib/Mongo/MongoGridFS.php
+++ b/lib/Mongo/MongoGridFS.php
@@ -444,4 +444,12 @@ class MongoGridFS extends MongoCollection
         return (is_array($result) && $result['ok'] == 1.0) ||
                (is_bool($result) && $result);
     }
+
+    /**
+     * @return array
+     */
+    public function __sleep()
+    {
+        return ['chunks', 'chunksName', 'database', 'defaultChunkSize', 'filesName', 'prefix'] + parent::__sleep();
+    }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -9,6 +9,11 @@ use Alcaeus\MongoDbAdapter\Tests\TestCase;
  */
 class MongoClientTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $this->assertInternalType('string', serialize($this->getClient()));
+    }
+
     public function testGetDb()
     {
         $client = $this->getClient();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -10,6 +10,11 @@ use Alcaeus\MongoDbAdapter\Tests\TestCase;
  */
 class MongoCollectionTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $this->assertInternalType('string', serialize($this->getCollection()));
+    }
+
     public function testGetNestedCollections()
     {
         $collection = $this->getCollection()->foo->bar;

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCommandCursorTest.php
@@ -10,6 +10,13 @@ use Alcaeus\MongoDbAdapter\Tests\TestCase;
  */
 class MongoCommandCursorTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $this->prepareData();
+        $cursor = $this->getCollection()->aggregateCursor([['$match' => ['foo' => 'bar']]]);
+        $this->assertInternalType('string', serialize($cursor));
+    }
+
     public function testInfo()
     {
         $this->prepareData();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
@@ -12,6 +12,13 @@ use MongoDB\Operation\Find;
  */
 class MongoCursorTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $this->prepareData();
+        $cursor = $this->getCollection()->find(['foo' => 'bar']);
+        $this->assertInternalType('string', serialize($cursor));
+    }
+
     public function testCursorConvertsTypes()
     {
         $this->prepareData();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
@@ -10,6 +10,11 @@ use MongoDB\Driver\ReadPreference;
  */
 class MongoDBTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $this->assertInternalType('string', serialize($this->getDatabase()));
+    }
+
     public function testEmptyDatabaseName()
     {
         $this->setExpectedException('Exception', 'Database name cannot be empty');

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
@@ -6,6 +6,12 @@ use Alcaeus\MongoDbAdapter\Tests\TestCase;
 
 class MongoDeleteBatchTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $batch = new \MongoDeleteBatch($this->getCollection());
+        $this->assertInternalType('string', serialize($batch));
+    }
+
     public function testDeleteOne()
     {
         $collection = $this->getCollection();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSCursorTest.php
@@ -6,6 +6,16 @@ use Alcaeus\MongoDbAdapter\Tests\TestCase;
 
 class MongoGridFSCursorTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $gridfs = $this->getGridFS();
+        $gridfs->storeBytes('foo', ['filename' => 'foo.txt']);
+        $gridfs->storeBytes('bar', ['filename' => 'bar.txt']);
+        $cursor = $gridfs->find(['filename' => 'foo.txt']);
+
+        $this->assertInternalType('string', serialize($cursor));
+    }
+
     public function testCursorItems()
     {
         $gridfs = $this->getGridFS();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSFileTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSFileTest.php
@@ -6,6 +6,15 @@ use Alcaeus\MongoDbAdapter\Tests\TestCase;
 
 class MongoGridFSFileTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $this->prepareFile('abcd', ['filename' => 'foo']);
+        $file = $this->getGridFS()->findOne(['filename' => 'foo']);
+        $this->assertInstanceOf(\MongoGridFSFile::class, $file);
+
+        $this->assertInternalType('string', serialize($file));
+    }
+
     public function testFileProperty()
     {
         $file = $this->getFile();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
@@ -6,6 +6,11 @@ use Alcaeus\MongoDbAdapter\Tests\TestCase;
 
 class MongoGridFSTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $this->assertInternalType('string', serialize($this->getGridFS()));
+    }
+
     public function testChunkProperty()
     {
         $collection = $this->getGridFS();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
@@ -6,6 +6,12 @@ use Alcaeus\MongoDbAdapter\Tests\TestCase;
 
 class MongoInsertBatchTest extends TestCase
 {
+    public function testSerialize()
+    {
+        $batch = new \MongoInsertBatch($this->getCollection());
+        $this->assertInternalType('string', serialize($batch));
+    }
+
     public function testInsertBatch()
     {
         $batch = new \MongoInsertBatch($this->getCollection());

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
@@ -6,7 +6,11 @@ use Alcaeus\MongoDbAdapter\Tests\TestCase;
 
 class MongoUpdateBatchTest extends TestCase
 {
-
+    public function testSerialize()
+    {
+        $batch = new \MongoUpdateBatch($this->getCollection());
+        $this->assertInternalType('string', serialize($batch));
+    }
 
     public function testUpdateOne()
     {


### PR DESCRIPTION
This adds `__sleep` methods to all classes that contain MongoDB driver classes to ensure no driver classes are being serialized. This will break those objects when unserializing them but it's the only thing possible to prevent fatal errors on serialization.