### PR TITLE
Prepare readme and changelog for beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+CHANGELOG
+=========
+
+This changelog references the relevant changes done in minor version updates.
+
+1.0.0-BETA1 (2016-02-xx)
+------------------------
+
+All issues and pull requests under this release may be found under the
+[1.0.0-BETA1](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.0.0-BETA1)
+milestone.
+
+ * [#52](https://github.com/alcaeus/mongo-php-adapter/pull/52) fixes behavior of
+ `MongoCollection::update` when no update operators have been given.
+ * [#53](https://github.com/alcaeus/mongo-php-adapter/pull/53) fixes an error
+ where some operations would send an invalid query to the MongoDB server,
+ causing command failures.
+ * [#54](https://github.com/alcaeus/mongo-php-adapter/pull/54) and
+ [#55](https://github.com/alcaeus/mongo-php-adapter/pull/55) fix the handling of
+ documents with numeric keys.
+ * [#56](https://github.com/alcaeus/mongo-php-adapter/pull/56) fixes the
+ behavior of `MongoGridFS::findOne` when no results are found.
+ * [#59](https://github.com/alcaeus/mongo-php-adapter/pull/59) adds handling for
+ the `includeSystemCollections` parameter in `MongoDB::getCollectionInfo` and
+ `MongoDB::getCollectionNames`.
+ * [#62](https://github.com/alcaeus/mongo-php-adapter/pull/62) removes the
+ manual comparison of index options to rely on the MongoDB server to decide
+ whether an index already exists.
+ * [#63](https://github.com/alcaeus/mongo-php-adapter/pull/63) prevents
+ serialization of driver classes which are not serializable.
+
+0.1.0 (2016-02-06)
+------------------
+
+Initial development release.

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ The preferred method of installing this library is with
 [Composer](https://getcomposer.org/) by running the following from your project
 root:
 
-    $ composer require "alcaeus/mongo-php-adapter=dev-master"
+    $ composer require "alcaeus/mongo-php-adapter=^1.0.0@beta"
 
-If your project includes a library that requires `ext-mongo` you need to also
+If your project requires a library that requires `ext-mongo` you need to also
 specify a `provide` option in your composer.json:
     "provide": {
         "ext-mongo": "1.6.12"
     }
 
-Due to a limitation in composer you need to specify this in the root package.
+Due to a limitation in composer you need to specify this in the **root package**.
 
 # Known issues
 


### PR DESCRIPTION
With the most obvious issues fixed and tests for doctrine/mongodb-odm passing when running with this library, the time has come to get the first beta release out the door.

The beta phase will be used to fix bugs people encounter while testing their projects against this library as well as simplifying installation, which still causes headaches for some people.