### PR TITLE
Prevent duplicate class declarations when not using autoloaders

### DIFF
--- a/lib/Mongo/Mongo.php
+++ b/lib/Mongo/Mongo.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('Mongo', false)) {
+    return;
+}
+
 /**
  * The connection point between MongoDB and PHP.
  * This class is used to initiate a connection and for database server commands.

--- a/lib/Mongo/MongoBinData.php
+++ b/lib/Mongo/MongoBinData.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoBinData', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeInterface;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Type;

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoClient', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\Helper;
 use Alcaeus\MongoDbAdapter\ExceptionConverter;
 use MongoDB\Client;

--- a/lib/Mongo/MongoCode.php
+++ b/lib/Mongo/MongoCode.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoCode', false)) {
+    return;
+}
+
 class MongoCode implements \Alcaeus\MongoDbAdapter\TypeInterface
 {
     /**

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoCollection', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\Helper;
 use Alcaeus\MongoDbAdapter\TypeConverter;
 use Alcaeus\MongoDbAdapter\ExceptionConverter;

--- a/lib/Mongo/MongoCommandCursor.php
+++ b/lib/Mongo/MongoCommandCursor.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoCommandCursor', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\AbstractCursor;
 use Alcaeus\MongoDbAdapter\TypeConverter;
 

--- a/lib/Mongo/MongoConnectionException.php
+++ b/lib/Mongo/MongoConnectionException.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoConnectionException', false)) {
+    return;
+}
+
 class MongoConnectionException extends MongoException {
 
 }

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoCursor', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\AbstractCursor;
 use Alcaeus\MongoDbAdapter\TypeConverter;
 use Alcaeus\MongoDbAdapter\ExceptionConverter;

--- a/lib/Mongo/MongoCursorException.php
+++ b/lib/Mongo/MongoCursorException.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoCursorException', false)) {
+    return;
+}
+
 class MongoCursorException extends MongoException {
 
 }

--- a/lib/Mongo/MongoCursorInterface.php
+++ b/lib/Mongo/MongoCursorInterface.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoCursorInterface', false)) {
+    return;
+}
+
 interface MongoCursorInterface extends Iterator
 {
     /**

--- a/lib/Mongo/MongoCursorTimeoutException.php
+++ b/lib/Mongo/MongoCursorTimeoutException.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoCursorTimeoutException', false)) {
+    return;
+}
+
 class MongoCursorTimeoutException extends MongoCursorException {
 
 }

--- a/lib/Mongo/MongoDB.php
+++ b/lib/Mongo/MongoDB.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoDB', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\Helper;
 use Alcaeus\MongoDbAdapter\TypeConverter;
 use Alcaeus\MongoDbAdapter\ExceptionConverter;

--- a/lib/Mongo/MongoDBRef.php
+++ b/lib/Mongo/MongoDBRef.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoDBRef', false)) {
+    return;
+}
+
 class MongoDBRef
 {
     /**

--- a/lib/Mongo/MongoDate.php
+++ b/lib/Mongo/MongoDate.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoDate', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeInterface;
 use MongoDB\BSON\UTCDateTime;
 

--- a/lib/Mongo/MongoDeleteBatch.php
+++ b/lib/Mongo/MongoDeleteBatch.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoDeleteBatch', false)) {
+    return;
+}
+
 /**
  * Constructs a batch of DELETE operations
  *

--- a/lib/Mongo/MongoDuplicateKeyException.php
+++ b/lib/Mongo/MongoDuplicateKeyException.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoDuplicateKeyException', false)) {
+    return;
+}
+
 /**
  * <p>(PECL mongo &gt;= 1.5.0)</p>
  * @link http://php.net/manual/en/class.mongoduplicatekeyexception.php

--- a/lib/Mongo/MongoException.php
+++ b/lib/Mongo/MongoException.php
@@ -13,5 +13,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoException', false)) {
+    return;
+}
+
 class MongoException extends Exception {
 }

--- a/lib/Mongo/MongoExecutionTimeoutException.php
+++ b/lib/Mongo/MongoExecutionTimeoutException.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoExecutionTimeoutException', false)) {
+    return;
+}
+
 /**
  * <p>(PECL mongo &gt;= 1.5.0)</p>
  * @link http://php.net/manual/en/class.mongoexecutiontimeoutexception.php

--- a/lib/Mongo/MongoGridFS.php
+++ b/lib/Mongo/MongoGridFS.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoGridFS', false)) {
+    return;
+}
+
 class MongoGridFS extends MongoCollection
 {
     const ASCENDING = 1;

--- a/lib/Mongo/MongoGridFSCursor.php
+++ b/lib/Mongo/MongoGridFSCursor.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoGridFSCursor', false)) {
+    return;
+}
+
 class MongoGridFSCursor extends MongoCursor
 {
     /**

--- a/lib/Mongo/MongoGridFSException.php
+++ b/lib/Mongo/MongoGridFSException.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoGridFSException', false)) {
+    return;
+}
+
 class MongoGridFSException extends MongoException {
 
 }

--- a/lib/Mongo/MongoGridFSFile.php
+++ b/lib/Mongo/MongoGridFSFile.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoGridFSFile', false)) {
+    return;
+}
+
 class MongoGridFSFile
 {
     /**

--- a/lib/Mongo/MongoId.php
+++ b/lib/Mongo/MongoId.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoId', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeInterface;
 use MongoDB\BSON\ObjectID;
 

--- a/lib/Mongo/MongoInsertBatch.php
+++ b/lib/Mongo/MongoInsertBatch.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoInsertBatch', false)) {
+    return;
+}
+
 /**
  * Constructs a batch of INSERT operations
  *

--- a/lib/Mongo/MongoInt32.php
+++ b/lib/Mongo/MongoInt32.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoInt32', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeInterface;
 
 class MongoInt32 implements TypeInterface

--- a/lib/Mongo/MongoInt64.php
+++ b/lib/Mongo/MongoInt64.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoInt64', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeInterface;
 
 class MongoInt64 implements TypeInterface

--- a/lib/Mongo/MongoLog.php
+++ b/lib/Mongo/MongoLog.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoLog', false)) {
+    return;
+}
+
 class MongoLog
 {
     /**

--- a/lib/Mongo/MongoMaxKey.php
+++ b/lib/Mongo/MongoMaxKey.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoMaxKey', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeInterface;
 use MongoDB\BSON\MaxKey;
 

--- a/lib/Mongo/MongoMinKey.php
+++ b/lib/Mongo/MongoMinKey.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoMinKey', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeInterface;
 use MongoDB\BSON\MinKey;
 

--- a/lib/Mongo/MongoPool.php
+++ b/lib/Mongo/MongoPool.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoPool', false)) {
+    return;
+}
+
 /**
  * @deprecated The current (1.3.0+) releases of the driver no longer implements pooling. This class and its methods are therefore deprecated and should not be used.
  */

--- a/lib/Mongo/MongoProtocolException.php
+++ b/lib/Mongo/MongoProtocolException.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoProtocolException', false)) {
+    return;
+}
+
 /**
  * <p>(PECL mongo &gt;= 1.5.0)</p>
  */

--- a/lib/Mongo/MongoRegex.php
+++ b/lib/Mongo/MongoRegex.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoRegex', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeInterface;
 use MongoDB\BSON\Regex;
 

--- a/lib/Mongo/MongoResultException.php
+++ b/lib/Mongo/MongoResultException.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoResultException', false)) {
+    return;
+}
+
 /**
  * <p>(PECL mongo &gt;= 1.3.0)</p>
  * @link http://php.net/manual/en/class.mongoresultexception.php#mongoresultexception.props.document

--- a/lib/Mongo/MongoTimestamp.php
+++ b/lib/Mongo/MongoTimestamp.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoTimestamp', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeInterface;
 use MongoDB\BSON\Timestamp;
 

--- a/lib/Mongo/MongoUpdateBatch.php
+++ b/lib/Mongo/MongoUpdateBatch.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoUpdateBatch', false)) {
+    return;
+}
+
 /**
  * Constructs a batch of UPDATE operations
  *

--- a/lib/Mongo/MongoWriteBatch.php
+++ b/lib/Mongo/MongoWriteBatch.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoWriteBatch', false)) {
+    return;
+}
+
 use Alcaeus\MongoDbAdapter\TypeConverter;
 use Alcaeus\MongoDbAdapter\Helper\WriteConcernConverter;
 

--- a/lib/Mongo/MongoWriteConcernException.php
+++ b/lib/Mongo/MongoWriteConcernException.php
@@ -13,6 +13,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (class_exists('MongoWriteConcernException', false)) {
+    return;
+}
+
 /**
  * <p>(PECL mongo &gt;= 1.5.0)</p>
  * @link http://php.net/manual/en/class.mongowriteconcernexception.php#class.mongowriteconcernexception


### PR DESCRIPTION
This will help people who are not relying on an autoloader to load the `Mongo*` classes on demand if they are not already present (e.g. because `ext-mongo` is installed). When installing `mongo-php-adapter` via composer and using the supplied autoloader, the classes will only be loaded when `ext_mongo` is not installed.