### PR TITLE
Throw warning in MongoCursor::timeout()

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ unserializing them.
  authentication information.
  - The [setFlag](https://php.net/manual/en/mongocursor.setflag.php)
  method is not yet implemented.
+ - The [timeout](https://php.net/manual/en/mongocursor.timeout.php) method will
+ not change any query options. Client-side timeouts are no longer supported by
+ the new driver. Use the maxTimeMS setting as a replacement.
 
 ## MongoCommandCursor
  - The [createFromDocument](https://php.net/manual/en/mongocommandcursor.createfromdocument.php)

--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -246,7 +246,8 @@ abstract class AbstractCursor
      */
     public function timeout($ms)
     {
-        $this->notImplemented();
+        trigger_error('The ' . __METHOD__ . ' method is not implemented in mongo-php-adapter', E_USER_WARNING);
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Closes #57.

This also adds a note to the readme to use the `maxTimeMS` setting as an alternative since `timeout` is no longer supported by the driver.