### PR TITLE
Use "latest" instead of version for pecl installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ php:
   - 7.0
 
 env:
-  - DRIVER_VERSION=1.1.1
+  - DRIVER_VERSION=stable
 
 matrix:
   include:
     - php: 5.6
-      env: DRIVER_VERSION=1.1.1 LEGACY_DRIVER_VERSION=1.6.12
+      env: DRIVER_VERSION=stable LEGACY_DRIVER_VERSION=stable
 
 addons:
   apt:

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
@@ -38,7 +38,12 @@ class MongoDateTest extends TestCase
         $this->assertInstanceOf('MongoDB\BSON\UTCDateTime', $bsonDate);
         $this->assertSame('1234567890123', (string) $bsonDate);
 
-        $this->assertEquals($dateTime, $bsonDate->toDateTime());
+        $bsonDateTime = $bsonDate->toDateTime();
+
+        // Compare timestamps to avoid issues with DateTime
+        $timestamp = $dateTime->format('U') . '.' . $dateTime->format('U');
+        $bsonTimestamp = $bsonDateTime->format('U') . '.' . $bsonDateTime->format('U');
+        $this->assertSame((float) $timestamp, (float) $bsonTimestamp);
     }
 
     public function testCreateWithBsonDate()


### PR DESCRIPTION
This PR also includes a fix for an unstable test regarding comparison of DateTime objects generated from BSON types.