### PR TITLE
Fix error when counting a closed cursor

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -7,6 +7,18 @@ This changelog references the relevant changes done in minor version updates.
 ------------------
 
 All issues and pull requests under this release may be found under the
+[1.0.3](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.0.3)
+milestone.
+
+ * [#96](https://github.com/alcaeus/mongo-php-adapter/pull/96) fixes errors when
+ calling `count` on a cursor that has been iterated fully. The fix removes a
+ performance improvement when calling `count` on a cursor that has been opened.
+ `MongoCursor::count` now always re-issues a `count` command to the server.
+
+1.0.2 (2016-04-08)
+------------------
+
+All issues and pull requests under this release may be found under the
 [1.0.2](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.0.2)
 milestone.
 

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -135,10 +135,6 @@ class MongoCursor extends AbstractCursor implements Iterator
      */
     public function count($foundOnly = false)
     {
-        if ($foundOnly && $this->cursor !== null) {
-            return iterator_count($this->ensureIterator());
-        }
-
         $optionNames = ['hint', 'maxTimeMS'];
         if ($foundOnly) {
             $optionNames = array_merge($optionNames, ['limit', 'skip']);

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
@@ -60,6 +60,18 @@ class MongoCursorTest extends TestCase
         $cursor->count();
     }
 
+    public function testCountAfterIteration()
+    {
+        $this->prepareData();
+
+        $collection = $this->getCollection();
+        $cursor = $collection->find(['foo' => 'bar']);
+
+        // Ensure the generator is consumed and thus closed
+        iterator_to_array($cursor);
+        $this->assertSame(2, $cursor->count(true));
+    }
+
     public function testNextStartsWithFirstItem()
     {
         $this->prepareData();


### PR DESCRIPTION
Fixes #95.

This removes a performance improvement designed to not issue a `count` command when the `foundOnly` option is set to `true` and the cursor has been opened. Unfortunately, when the generator wrapping the original result cursor is closed, `iterator_count` causes an error.