### PR TITLE
Fix toDateTime issue on PHP with non UTC timezone set

### DIFF
--- a/lib/Mongo/MongoDate.php
+++ b/lib/Mongo/MongoDate.php
@@ -95,6 +95,8 @@ class MongoDate implements TypeInterface
             $datetime = \DateTime::createFromFormat('Y-m-d H:i:s.u', $datetime->format('Y-m-d H:i:s') . '.' . $microSeconds);
         }
 
+        $datetime->setTimezone(new \DateTimeZone("UTC"));
+
         return $datetime;
     }
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
@@ -10,6 +10,24 @@ use Alcaeus\MongoDbAdapter\TypeInterface;
  */
 class MongoDateTest extends TestCase
 {
+    public function testTimeZoneDoesNotAlterReturnedDateTime()
+    {
+        $initialTZ = ini_get("date.timezone");
+
+        ini_set("date.timezone", "UTC");
+
+        // Today at 8h 8m 8s
+        $timestamp = mktime (8, 8, 8); $date = new \MongoDate($timestamp);
+
+        $this->assertSame('08:08:08', $date->toDateTime()->format("H:i:s"));
+
+        ini_set("date.timezone", "Europe/Paris");
+
+        $this->assertSame('08:08:08', $date->toDateTime()->format("H:i:s"));
+
+        ini_set("date.timezone", $initialTZ);
+    }
+
     public function testCreate()
     {
         $date = new \MongoDate(1234567890, 123456);


### PR DESCRIPTION
The MondoDB adapter does not return the same date as the original PHP5 mongo extension in my case. 

Running this in both PHP7 and PHP5 containers return different results:

```
php -r 'require_once __DIR__ . "/app/bootstrap.php.cache"; $d = new \MongoDate(); var_dump(ini_get("date.timezone"), $d->toDateTime(), $d->toDateTime()->format("H:i:s"));'; date
```

## PHP7 + mongodb 1.1.5 + adapter

```
string(12) "Europe/Paris"
object(DateTime)#4 (3) {
  ["date"]=>
  string(26) "2016-05-20 13:38:40.695000"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(12) "Europe/Paris"
}
string(8) "13:38:40"
Fri May 20 11:38:40 UTC 2016
```

## PHP5 + mongo ext 1.6.10

```
string(12) "Europe/Paris"
object(DateTime)#3 (3) {
  ["date"]=>
  string(26) "2016-05-20 11:38:48.505000"
  ["timezone_type"]=>
  int(1)
  ["timezone"]=>
  string(6) "+00:00"
}
string(8) "11:38:48"
Fri May 20 11:38:48 UTC 2016
```

As you can see, the legacy mongo extension always returned PHP DateTime in the `+00:00` timezone, and the MongoDate from this adapter use the default timezone, which depends on the `date.timezone` setting.

This pull request attempt to fix this by forcing UTC for all generated DateTime's.