### PR TITLE
fix and test for MongoCollection::aggregate

### DIFF
--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -131,11 +131,12 @@ class MongoCollection
     public function aggregate(array $pipeline, array $op = [])
     {
         if (! TypeConverter::isNumericArray($pipeline)) {
+            $operators = func_get_args();
             $pipeline = [];
             $options = [];
 
             $i = 0;
-            foreach (func_get_args() as $operator) {
+            foreach ($operators as $operator) {
                 $i++;
                 if (! is_array($operator)) {
                     trigger_error("Argument $i is not an array", E_WARNING);

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -600,6 +600,32 @@ class MongoCollectionTest extends TestCase
         ], $result['result']);
     }
 
+    public function testAggregateWithMultiplePilelineOperatorsAsArguments()
+    {
+        $collection = $this->getCollection();
+
+        try {
+            $collection->aggregate(
+                [
+                    '$group' => [
+                        '_id' => '$foo',
+                        'count' => [ '$sum' => 1 ],
+                    ],
+                ],
+                [
+                    '$sort' => ['_id' => 1]
+                ]
+            );
+            $this->assertTrue(true);
+
+        } catch (\MongoResultException $ex) {
+            $msg = 'MongoCollection::aggregate ( array $op [, array $op [, array $... ]] ) should accept variable amount of pipeline operators as argument'
+                . "\n"
+                . $ex;
+            $this->fail($msg);
+        }
+    }
+
     public function testAggregateInvalidPipeline()
     {
         $collection = $this->getCollection();


### PR DESCRIPTION
This method should accept a variable amount of pipeline operators
MongoCollection::aggregate ( array $op [, array $op [, array $... ]] )

https://github.com/alcaeus/mongo-php-adapter/issues/114
http://www.php.net/manual/en/mongocollection.aggregate.php