### PR TITLE
Fix the Collection::getIndexInfo method for missing "unique" option

### DIFF
--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -705,12 +705,18 @@ class MongoCollection
     public function getIndexInfo()
     {
         $convertIndex = function(\MongoDB\Model\IndexInfo $indexInfo) {
-            return [
+            $infos = [
                 'v' => $indexInfo->getVersion(),
                 'key' => $indexInfo->getKey(),
                 'name' => $indexInfo->getName(),
                 'ns' => $indexInfo->getNamespace(),
             ];
+
+            if ($indexInfo->isUnique()) {
+                $infos['unique'] = true;
+            }
+
+            return $infos;
         };
 
         return array_map($convertIndex, iterator_to_array($this->collection->listIndexes()));
@@ -1009,4 +1015,3 @@ class MongoCollection
         return ['db', 'name'];
     }
 }
-

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -1143,6 +1143,7 @@ class MongoCollectionTest extends TestCase
     {
         $collection = $this->getCollection();
         $collection->createIndex(['foo' => 1]);
+        $collection->createIndex(['bar' => 1], ['unique' => true]);
 
         $expected = [
             [
@@ -1157,9 +1158,16 @@ class MongoCollectionTest extends TestCase
                 'name' => 'foo_1',
                 'ns' => 'mongo-php-adapter.test',
             ],
+            [
+                'v' => 1,
+                'key' => ['bar' => 1],
+                'name' => 'bar_1',
+                'ns' => 'mongo-php-adapter.test',
+                'unique' => true,
+            ],
         ];
 
-        $this->assertSame(
+        $this->assertEquals(
             $expected,
             $collection->getIndexInfo()
         );


### PR DESCRIPTION
I saw this issue when dealing with a bug in Doctrine ODM. They have a command handling indexes changes.

In that command, they check that the defined mapping is the same as the indexes returned by mongodb ([code here for the curious](https://github.com/doctrine/mongodb-odm/blob/63382fb83642047bdf37528e9069e0d3809857b8/lib/Doctrine/ODM/MongoDB/SchemaManager.php#L456)). If not, unknown indexes are removed, and then "ensureIndexes" is called.

I got a very bad situation in production where some of my indices were removed, and re-created, which was taking a very long time and basically broke everything ([and was doing so in total absence of error exit](https://github.com/doctrine/DoctrineMongoDBBundle/pull/369)). 

## What is wrong

The `isMongoIndexEquivalentToDocumentIndex` from Doctrine was not returning true when comparing some of my indexes. 

That's because the response from the old Mongo extension and what mongo-php-adapter returns is not always the same, especially when there is the `unique` option set on the index.

## The fix

Adding back the `unique` key in the array was enough to fix the bug in the schema update command, but I took a look inside the old Mongo extension and server code and it looks like that the option is only returned if it's true ([code here](https://github.com/mongodb/mongo/blob/e324289ed29a41f0f6f610dc63ab5d2ce1f9c351/src/mongo/s/cluster_write.cpp#L96)), so I added a small `if` to mimic this behavior too.

Thanks :beers: 