### PR TITLE
Throw MongoWriteConcernException on bulk write errors

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -12,6 +12,8 @@ milestone.
 
  * [#117](https://github.com/alcaeus/mongo-php-adapter/pull/117) adds a missing
  flag to indexes when calling `MongoCollection::getIndexInfo`.
+ * [#120](https://github.com/alcaeus/mongo-php-adapter/pull/120) throws the proper
+ `MongoWriteConcernException` when encountering bulk write errors.
 
 1.0.4 (2016-06-22)
 ------------------

--- a/lib/Mongo/MongoWriteConcernException.php
+++ b/lib/Mongo/MongoWriteConcernException.php
@@ -21,11 +21,34 @@ if (class_exists('MongoWriteConcernException', false)) {
  * <p>(PECL mongo &gt;= 1.5.0)</p>
  * @link http://php.net/manual/en/class.mongowriteconcernexception.php#class.mongowriteconcernexception
  */
-class MongoWriteConcernException extends MongoCursorException {
+class MongoWriteConcernException extends MongoCursorException
+{
+    private $document;
+
+    /**
+     * MongoWriteConcernException constructor.
+     *
+     * @param string $message
+     * @param int $code
+     * @param Exception|null $previous
+     * @param null $document
+     *
+     * @internal The $document parameter is not part of the ext-mongo API
+     */
+    public function __construct($message = '', $code = 0, Exception $previous = null, $document = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->document = $document;
+    }
+
     /**
      * Get the error document
      * @link http://php.net/manual/en/mongowriteconcernexception.getdocument.php
      * @return array <p>A MongoDB document, if available, as an array.</p>
      */
-    public function getDocument() {}
+    public function getDocument()
+    {
+        return $this->document;
+    }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
@@ -58,7 +58,6 @@ class MongoDeleteBatchTest extends TestCase
         $this->assertSame(0, $newCollection->count());
     }
 
-
     public function testValidateItem()
     {
         $collection = $this->getCollection();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
@@ -56,8 +56,10 @@ class MongoInsertBatchTest extends TestCase
 
         try {
             $batch->execute();
+            $this->fail('Expected MongoWriteConcernException');
         } catch (\MongoWriteConcernException $e) {
             $this->assertSame('Failed write', $e->getMessage());
+            $this->assertSame(911, $e->getCode());
             $this->assertArraySubset($expected, $e->getDocument());
         }
     }


### PR DESCRIPTION
This PR supersedes #118 and adds the proper result document to the exception. Since I didn't want to expose a setter for the document property in the exception I decided to not include this in the ExceptionConverter but instead convert this exception manually within the BulkWriteClass.

Todos:
- [x] Harden tests for Update and Delete bulk actions
- [x] Ensure proper exception code is thrown in MongoWriteConcernException