### PR TITLE
Fix findAndModify when specifying update param and option

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -14,6 +14,9 @@ milestone.
  flag to indexes when calling `MongoCollection::getIndexInfo`.
  * [#120](https://github.com/alcaeus/mongo-php-adapter/pull/120) throws the proper
  `MongoWriteConcernException` when encountering bulk write errors.
+ * [#122](https://github.com/alcaeus/mongo-php-adapter/pull/122) fixes an error in
+ `MongoCollection::findAndModify` when specifying both the `update` parameter as
+ well as the `update` option.
 
 1.0.4 (2016-06-22)
 ------------------

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -503,7 +503,7 @@ class MongoCollection
             } else {
                 $update = is_array($update) ? $update : [];
                 if (isset($options['update']) && is_array($options['update'])) {
-                    $update = array_merge($update, $options['update']);
+                    $update = $options['update'];
                     unset($options['update']);
                 }
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -1254,6 +1254,35 @@ class MongoCollectionTest extends TestCase
         $this->assertObjectNotHasAttribute('foo', $object);
     }
 
+    public function testFindAndModifyWithUpdateParamAndOption()
+    {
+        $id = '54203e08d51d4a1f868b456e';
+        $collection = $this->getCollection();
+
+        $document = ['_id' => new \MongoId($id), 'foo' => 'bar'];
+        $collection->insert($document);
+
+        $data = ['foo' => 'foo', 'bar' => 'bar'];
+
+        $this->getCollection()->findAndModify(
+            ['_id' => new \MongoId($id)],
+            [$data],
+            [],
+            [
+                'update' => ['$set' => ['foo' => 'foobar']],
+                'upsert' => true,
+            ]
+        );
+
+        $newCollection = $this->getCheckDatabase()->selectCollection('test');
+        $this->assertSame(1, $newCollection->count());
+        $object = $newCollection->findOne();
+
+        $this->assertNotNull($object);
+        $this->assertAttributeSame('foobar', 'foo', $object);
+        $this->assertObjectNotHasAttribute('bar', $object);
+    }
+
     public function testFindAndModifyUpdateReplace()
     {
         $id = '54203e08d51d4a1f868b456e';


### PR DESCRIPTION
Fixes #121. This occurs when passing values to the update parameter and at the same time specifying the update option containing an atomic operator.