### PR TITLE
Add implementation of JsonSerializable to MongoId

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -12,6 +12,8 @@ milestone.
 
  * [#126](https://github.com/alcaeus/mongo-php-adapter/pull/126) fixes a class
  name that was improperly capitalized.
+ * [#130](https://github.com/alcaeus/mongo-php-adapter/pull/130) fixes JSON
+ serialization of `MongoId` objects.
 
 1.0.5 (2016-07-03)
 ------------------

--- a/lib/Mongo/MongoId.php
+++ b/lib/Mongo/MongoId.php
@@ -20,7 +20,7 @@ if (class_exists('MongoId', false)) {
 use Alcaeus\MongoDbAdapter\TypeInterface;
 use MongoDB\BSON\ObjectID;
 
-class MongoId implements Serializable, TypeInterface
+class MongoId implements Serializable, TypeInterface, JsonSerializable
 {
     /*
      * @var ObjectID
@@ -198,6 +198,16 @@ class MongoId implements Serializable, TypeInterface
     public static function __set_state(array $props)
     {
 
+    }
+
+    /**
+     * @return stdClass
+     */
+    public function jsonSerialize()
+    {
+        $object = new stdClass();
+        $object->{'$id'} = (string) $this->objectID;
+        return $object;
     }
 
     /**

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoIdTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoIdTest.php
@@ -24,6 +24,9 @@ class MongoIdTest extends TestCase
         $unserialized = unserialize($serialized);
         $this->assertInstanceOf('MongoId', $unserialized);
         $this->assertSame($stringId, (string) $unserialized);
+
+        $json = json_encode($id);
+        $this->assertSame(sprintf('{"$id":"%s"}', $stringId), $json);
     }
 
     public function testCreateWithString()


### PR DESCRIPTION
This backports #129 into the 1.0.x branch.