### PR TITLE
Need to remove link (&) from the save() method

### DIFF
--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -766,7 +766,7 @@ class MongoCollection
      * @return array|boolean If w was set, returns an array containing the status of the save.
      * Otherwise, returns a boolean representing if the array was not empty (an empty array will not be inserted).
      */
-    public function save(&$a, array $options = [])
+    public function save($a, array $options = [])
     {
         $id = $this->ensureDocumentHasMongoId($a);
 


### PR DESCRIPTION
This should be done for full compatibility.
For example: save(['data' => '...']) causes an PHP Fatal error: Uncaught Error: Cannot pass parameter 1 by reference.