### PR TITLE
Fix wrong usage of trigger_error

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/Helper/ReadPreference.php
+++ b/lib/Alcaeus/MongoDbAdapter/Helper/ReadPreference.php
@@ -106,12 +106,12 @@ trait ReadPreference
                 $mode = \MongoDB\Driver\ReadPreference::RP_NEAREST;
                 break;
             default:
-                trigger_error("The value '$readPreference' is not valid as read preference type", E_WARNING);
+                trigger_error("The value '$readPreference' is not valid as read preference type", E_USER_WARNING);
                 return false;
         }
 
         if ($readPreference == \MongoClient::RP_PRIMARY && count($tags)) {
-            trigger_error("You can't use read preference tags with a read preference of PRIMARY", E_WARNING);
+            trigger_error("You can't use read preference tags with a read preference of PRIMARY", E_USER_WARNING);
             return false;
         }
 

--- a/lib/Alcaeus/MongoDbAdapter/Helper/WriteConcernConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/Helper/WriteConcernConverter.php
@@ -25,7 +25,7 @@ trait WriteConcernConverter
     protected function createWriteConcernFromParameters($wstring, $wtimeout)
     {
         if (! is_string($wstring) && ! is_int($wstring)) {
-            trigger_error("w for WriteConcern must be a string or integer", E_WARNING);
+            trigger_error("w for WriteConcern must be a string or integer", E_USER_WARNING);
             return false;
         }
 

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -139,7 +139,7 @@ class MongoCollection
             foreach ($operators as $operator) {
                 $i++;
                 if (! is_array($operator)) {
-                    trigger_error("Argument $i is not an array", E_WARNING);
+                    trigger_error("Argument $i is not an array", E_USER_WARNING);
                     return;
                 }
 
@@ -548,7 +548,7 @@ class MongoCollection
     {
         // Can't typehint for array since MongoGridFS extends and accepts strings
         if (! is_array($query)) {
-            trigger_error(sprintf('MongoCollection::findOne(): expects parameter 1 to be an array or object, %s given', gettype($query)), E_WARNING);
+            trigger_error(sprintf('MongoCollection::findOne(): expects parameter 1 to be an array or object, %s given', gettype($query)), E_USER_WARNING);
             return;
         }
 

--- a/lib/Mongo/MongoDB.php
+++ b/lib/Mongo/MongoDB.php
@@ -116,7 +116,7 @@ class MongoDB
     public function __set($name, $value)
     {
         if ($name === 'w' || $name === 'wtimeout') {
-            trigger_error("The '{$name}' property is read-only", E_DEPRECATED);
+            trigger_error("The '{$name}' property is read-only", E_USER_DEPRECATED);
         }
     }
 

--- a/lib/Mongo/MongoGridFS.php
+++ b/lib/Mongo/MongoGridFS.php
@@ -63,7 +63,7 @@ class MongoGridFS extends MongoCollection
     public function __construct(MongoDB $db, $prefix = "fs", $chunks = null)
     {
         if ($chunks) {
-            trigger_error("The 'chunks' argument is deprecated and ignored", E_DEPRECATED);
+            trigger_error("The 'chunks' argument is deprecated and ignored", E_USER_DEPRECATED);
         }
         if (empty($prefix)) {
             throw new \Exception('MongoGridFS::__construct(): invalid prefix');

--- a/lib/Mongo/MongoGridFSFile.php
+++ b/lib/Mongo/MongoGridFSFile.php
@@ -79,7 +79,7 @@ class MongoGridFSFile
         }
 
         if (! $handle = fopen($filename, 'w')) {
-            trigger_error(E_ERROR, 'Can not open the destination file');
+            trigger_error('Can not open the destination file', E_USER_ERROR);
             return 0;
         }
 

--- a/lib/Mongo/MongoId.php
+++ b/lib/Mongo/MongoId.php
@@ -101,7 +101,7 @@ class MongoId implements Serializable, TypeInterface, JsonSerializable
     public function __set($name, $value)
     {
         if ($name === 'id') {
-            trigger_error("The '\$id' property is read-only", E_DEPRECATED);
+            trigger_error("The '\$id' property is read-only", E_USER_DEPRECATED);
             return;
         }
     }
@@ -121,7 +121,7 @@ class MongoId implements Serializable, TypeInterface, JsonSerializable
     public function __unset($name)
     {
         if ($name === 'id') {
-            trigger_error("The '\$id' property is read-only", E_DEPRECATED);
+            trigger_error("The '\$id' property is read-only", E_USER_DEPRECATED);
             return;
         }
     }

--- a/lib/Mongo/MongoPool.php
+++ b/lib/Mongo/MongoPool.php
@@ -30,7 +30,7 @@ class MongoPool
      */
     public static function info()
     {
-        trigger_error('Function MongoPool::info() is deprecated', E_DEPRECATED);
+        trigger_error('Function MongoPool::info() is deprecated', E_USER_DEPRECATED);
         return [];
     }
 
@@ -43,7 +43,7 @@ class MongoPool
      */
     public static function setSize($size)
     {
-        trigger_error('Function MongoPool::info() is deprecated', E_DEPRECATED);
+        trigger_error('Function MongoPool::info() is deprecated', E_USER_DEPRECATED);
         return 1;
     }
 
@@ -55,7 +55,7 @@ class MongoPool
      */
     public static function getSize()
     {
-        trigger_error('Function MongoPool::info() is deprecated', E_DEPRECATED);
+        trigger_error('Function MongoPool::info() is deprecated', E_USER_DEPRECATED);
         return 1;
     }
 }

--- a/lib/Mongo/MongoWriteBatch.php
+++ b/lib/Mongo/MongoWriteBatch.php
@@ -107,10 +107,10 @@ class MongoWriteBatch
         }
 
         if (isset($writeOptions['j'])) {
-            trigger_error('j parameter is not supported', E_WARNING);
+            trigger_error('j parameter is not supported', E_USER_WARNING);
         }
         if (isset($writeOptions['fsync'])) {
-            trigger_error('fsync parameter is not supported', E_WARNING);
+            trigger_error('fsync parameter is not supported', E_USER_WARNING);
         }
 
         $options['writeConcern'] = $this->createWriteConcernFromArray($writeOptions);


### PR DESCRIPTION
Fixes #135.

This uses the `E_USER_*` error codes consistently when calling `trigger_error`. While it may be more compatible with the legacy driver to use `E_WARNING`, `trigger_error` will trigger a different error, obscuring the original error condition. Thus, it makes more sense to use E_USER_WARNING and deal with any incompatibilities.