### PR TITLE
Convert legacy projection syntax before applying

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
@@ -88,6 +88,26 @@ class TypeConverter
     }
 
     /**
+     * Converts a projection used in find queries.
+     *
+     * This method handles conversion from the legacy syntax (e.g. ['x', 'y', 'z'])
+     * to the new syntax (e.g. ['x' => true, 'y' => true, 'z' => true]). While
+     * this was never documented, the legacy driver applied the same conversion.
+     *
+     * @param array $fields
+     * @return array
+     */
+    public static function convertProjection($fields)
+    {
+        if (! is_array($fields) || $fields === []) {
+            return [];
+        }
+
+        $projection = TypeConverter::isNumericArray($fields) ? array_fill_keys($fields, true) : $fields;
+        return TypeConverter::fromLegacy($projection);
+    }
+
+    /**
      * Helper method to find out if an array has numerical indexes
      *
      * For performance reason, this method checks the first array index only.

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -514,7 +514,7 @@ class MongoCollection
                     unset($options['new']);
                 }
 
-                $options['projection'] = is_array($fields) ? TypeConverter::fromLegacy($fields) : [];
+                $options['projection'] = TypeConverter::convertProjection($fields);
 
                 if (! \MongoDB\is_first_key_operator($update)) {
                     $document = $this->collection->findOneAndReplace($query, $update, $options);
@@ -552,7 +552,7 @@ class MongoCollection
             return;
         }
 
-        $options = ['projection' => TypeConverter::fromLegacy($fields)] + $options;
+        $options = ['projection' => TypeConverter::convertProjection($fields)] + $options;
         try {
             $document = $this->collection->findOne(TypeConverter::fromLegacy($query), $options);
         } catch (\MongoDB\Driver\Exception\Exception $e) {

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -431,7 +431,7 @@ class MongoCursor extends AbstractCursor implements Iterator
      */
     protected function convertProjection()
     {
-        return TypeConverter::fromLegacy($this->projection);
+        return TypeConverter::convertProjection($this->projection);
     }
 
     /**

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -1559,8 +1559,6 @@ class MongoCollectionTest extends TestCase
                 'keysPerIndex' => ['mongo-php-adapter.test.$_id_' => 1],
                 'valid' => true,
                 'errors' => [],
-                'warning' => 'Some checks omitted for speed. use {full:true} option to do more thorough scan.',
-                'ok'  => 1.0
             ],
             $result
         );

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -429,6 +429,35 @@ class MongoCollectionTest extends TestCase
         $this->assertInstanceOf('MongoCursor', $collection->find());
     }
 
+    public function testFindWithProjection()
+    {
+        $document = ['foo' => 'foo', 'bar' => 'bar'];
+        $this->getCollection()->insert($document);
+        unset($document['_id']);
+        $this->getCollection()->insert($document);
+
+        $cursor = $this->getCollection()->find(['foo' => 'foo'], ['bar' => true]);
+        foreach ($cursor as $document) {
+            $this->assertCount(2, $document);
+            $this->assertArraySubset(['bar' => 'bar'], $document);
+        }
+    }
+
+    public function testFindWithLegacyProjection()
+    {
+        $document = ['foo' => 'foo', 'bar' => 'bar'];
+        $this->getCollection()->insert($document);
+        unset($document['_id']);
+        $this->getCollection()->insert($document);
+
+        $cursor = $this->getCollection()->find(['foo' => 'foo'], ['bar']);
+        foreach ($cursor as $document) {
+            $this->assertCount(2, $document);
+            $this->assertArraySubset(['bar' => 'bar'], $document);
+        }
+    }
+
+
     public function testCount()
     {
         $this->prepareData();
@@ -508,6 +537,26 @@ class MongoCollectionTest extends TestCase
 
         $document = $this->getCollection()->findOne(['foo' => 'foo'], ['_id' => false]);
         $this->assertSame(['foo' => 'foo'], $document);
+    }
+
+    public function testFindOneWithProjection()
+    {
+        $document = ['foo' => 'foo', 'bar' => 'bar'];
+        $this->getCollection()->insert($document);
+
+        $document = $this->getCollection()->findOne(['foo' => 'foo'], ['bar' => true]);
+        $this->assertCount(2, $document);
+        $this->assertArraySubset(['bar' => 'bar'], $document);
+    }
+
+    public function testFindOneWithLegacyProjection()
+    {
+        $document = ['foo' => 'foo', 'bar' => 'bar'];
+        $this->getCollection()->insert($document);
+
+        $document = $this->getCollection()->findOne(['foo' => 'foo'], ['bar']);
+        $this->assertCount(2, $document);
+        $this->assertArraySubset(['bar' => 'bar'], $document);
     }
 
     public function testFindOneNotFound()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
@@ -287,6 +287,18 @@ class MongoGridFSTest extends TestCase
         $this->assertInstanceOf('MongoGridFSFile', $result);
     }
 
+    public function testFindOneWithLegacyProjectionReturnsFile()
+    {
+        $collection = $this->getGridFS();
+        $this->prepareFile('abcd', ['date' => new \MongoDate()]);
+
+        $result = $collection->findOne([], ['date']);
+
+        $this->assertInstanceOf('MongoGridFSFile', $result);
+        $this->assertCount(2, $result->file);
+        $this->assertArrayHasKey('date', $result->file);
+    }
+
     public function testFindOneWithFilenameReturnsFile()
     {
         $collection = $this->getGridFS();


### PR DESCRIPTION
Fixes #144.

This was never properly documented in the driver, but has been there for quite some time. Digging into the code, I found the following comment ([source](https://github.com/mongodb/mongo-php-driver-legacy/blob/e6f687cd12dea23da23ca8a9a9a98eda1e0e0ecc/cursor.c#L107..L112)):
> Legacy handling where the projection is an array of field names to be included (e.g. ['x', 'y', 'z'] is converted to {'x': 1, 'y': 1, 'z': 1}).
> This behavior dates back to 0.9.4, but there is no record of it in the extension's documentation. It should be deprecated/removed in the future, as it conflicts with supporting some legitimate projections (PHP-1056).

Thus, it's sensible to apply the same conversion whenever a projection is applied to a query.