### PR TITLE
Allow using bools for writeConcern

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -10,6 +10,9 @@ All issues and pull requests under this release may be found under the
 [1.0.8](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.0.8)
 milestone.
 
+ * [#151](https://github.com/alcaeus/mongo-php-adapter/pull/151) allows using
+ boolean values when passing a write concern option to an insert or update. While
+ never documented, this was happily accepted by the legacy driver.
  * [#150](https://github.com/alcaeus/mongo-php-adapter/pull/150) adds missing
  options to `MongoCollection::indexInfo`.
  * [#149](https://github.com/alcaeus/mongo-php-adapter/pull/149) fixes calls to

--- a/lib/Alcaeus/MongoDbAdapter/Helper/WriteConcernConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/Helper/WriteConcernConverter.php
@@ -18,12 +18,17 @@ namespace Alcaeus\MongoDbAdapter\Helper;
 trait WriteConcernConverter
 {
     /**
-     * @param string|int $wstring
+     * @param string|int|bool $wstring
      * @param int $wtimeout
      * @return \MongoDB\Driver\WriteConcern
      */
     protected function createWriteConcernFromParameters($wstring, $wtimeout)
     {
+        // Convert legacy write concern
+        if (is_bool($wstring)) {
+            $wstring = (int) $wstring;
+        }
+
         if (! is_string($wstring) && ! is_int($wstring)) {
             trigger_error("w for WriteConcern must be a string or integer", E_USER_WARNING);
             return false;

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -132,6 +132,26 @@ class MongoCollectionTest extends TestCase
         $this->assertTrue($this->getCollection()->insert($document, ['w' => 0]));
     }
 
+    public function testUnacknowledgedWriteWithBooleanValue()
+    {
+        $document = ['foo' => 'bar'];
+        $this->assertTrue($this->getCollection()->insert($document, ['w' => false]));
+    }
+
+    public function testAcknowledgedWriteConcernWithBool()
+    {
+        $document = ['foo' => 'bar'];
+        $this->assertSame(
+            [
+                'ok' => 1.0,
+                'n' => 0,
+                'err' => null,
+                'errmsg' => null,
+            ],
+            $this->getCollection()->insert($document, ['w' => true])
+        );
+    }
+
     public function testInsertWriteConcernException()
     {
         $this->setExpectedException(


### PR DESCRIPTION
Fixes #146. While `MongoCollection::setWriteConcern` expects the `w` option to be a string or integer, one can pass a boolean as `w` option to insert and update commands. To avoid a BC break for people who might have been using this undocumented feature, the WriteConcernConverter will cast a bool to int, resulting in a valid writeConcern object. While this will cause a minor inconsistency in `MongoCollection::setWriteConcern` (which no longer throws an error in the adapter), avoiding the BC break has priority.