### PR TITLE
Allow int parameter for MongoGridFS::findOne

### DIFF
--- a/lib/Mongo/MongoGridFS.php
+++ b/lib/Mongo/MongoGridFS.php
@@ -132,7 +132,7 @@ class MongoGridFS extends MongoCollection
     public function findOne($query = [], array $fields = [], array $options = [])
     {
         if (! is_array($query)) {
-            $query = ['filename' => (string) $query];
+            $query = ['filename' => $query];
         }
 
         $items = iterator_to_array($this->find($query, $fields)->limit(1));

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
@@ -312,6 +312,19 @@ class MongoGridFSTest extends TestCase
         $this->assertSame('test', $result->getBytes());
     }
 
+    public function testFindOneWithIntegerFilenameReturnsFile()
+    {
+        $collection = $this->getGridFS();
+        $this->prepareFile(1, ['filename' => 1]);
+        $this->prepareFile(2, ['filename' => 2]);
+        $this->prepareFile(3, ['filename' => 3]);
+
+        $result = $collection->findOne(1);
+
+        $this->assertInstanceOf('MongoGridFSFile', $result);
+        $this->assertSame('1', $result->getBytes());
+    }
+
     public function testFindOneNotFoundReturnsNull()
     {
         $collection = $this->getGridFS();


### PR DESCRIPTION
FindOne with int as param works in PHP5.5 with old php extension and we need it to work with PHP7 and mongo-php-adapter. We think this is a bug.