### PR TITLE
Fixed handling of milliseconds with leading zeroes

### DIFF
--- a/lib/Mongo/MongoDate.php
+++ b/lib/Mongo/MongoDate.php
@@ -92,7 +92,7 @@ class MongoDate implements TypeInterface
 
         $microSeconds = $this->truncateMicroSeconds($this->usec);
         if ($microSeconds > 0) {
-            $datetime = \DateTime::createFromFormat('Y-m-d H:i:s.u', $datetime->format('Y-m-d H:i:s') . '.' . $microSeconds);
+            $datetime = \DateTime::createFromFormat('Y-m-d H:i:s.u', $datetime->format('Y-m-d H:i:s') . '.' . str_pad($microSeconds, 6, '0', STR_PAD_LEFT));
         }
 
         $datetime->setTimezone(new \DateTimeZone("UTC"));

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
@@ -81,4 +81,17 @@ class MongoDateTest extends TestCase
         $this->assertAttributeSame(1234567890, 'sec', $date);
         $this->assertAttributeSame(123000, 'usec', $date);
     }
+
+    public function testSupportMillisecondsWithLeadingZeroes()
+    {
+        $date = new \MongoDate('1234567890', '012345');
+        $this->assertAttributeSame(1234567890, 'sec', $date);
+        $this->assertAttributeSame(12000, 'usec', $date);
+
+        $this->assertSame('0.01200000 1234567890', (string) $date);
+        $dateTime = $date->toDateTime();
+
+        $this->assertSame(1234567890, $dateTime->getTimestamp());
+        $this->assertSame('012000', $dateTime->format('u'));
+    }
 }


### PR DESCRIPTION
This PR fixes `MongoDate`s handling of microsecond strings with leading zeroes. See the attached test case for details.