### PR TITLE
Fix failing MongoDB 3.4 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,57 @@
 sudo: false
 language: php
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-
-env:
-  - DRIVER_VERSION=stable
+services:
+  - mongodb
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.6
-      env: DRIVER_VERSION=stable LEGACY_DRIVER_VERSION=stable
+      env: DRIVER_VERSION=stable LEGACY_DRIVER_VERSION=stable COMPOSER_FLAGS="--prefer-dist --prefer-lowest" SERVER_VERSION=3.0 COLUMNS=80
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse"
+              key_url: "https://www.mongodb.org/static/pgp/server-3.0.asc"
+            - "mongodb-upstart"
+          packages: ['mongodb-org-server']
     - php: 5.6
-      env: DRIVER_VERSION=stable COMPOSER_FLAGS="--prefer-dist --prefer-lowest"
+      env: DRIVER_VERSION=stable SERVER_VERSION=3.4
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse"
+              key_url: "https://www.mongodb.org/static/pgp/server-3.4.asc"
+            - "mongodb-upstart"
+          packages: ['mongodb-org-server']
+    - php: 7.0
+      env: DRIVER_VERSION=stable SERVER_VERSION=3.4
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse"
+              key_url: "https://www.mongodb.org/static/pgp/server-3.4.asc"
+            - "mongodb-upstart"
+          packages: ['mongodb-org-server']
+    - php: 7.1
+      env: DRIVER_VERSION=stable SERVER_VERSION=3.4
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse"
+              key_url: "https://www.mongodb.org/static/pgp/server-3.4.asc"
+            - "mongodb-upstart"
+          packages: ['mongodb-org-server']
 
-addons:
-  apt:
-    sources:
-    - mongodb-3.2-precise
-    packages:
-    - mongodb-org-server
-
-before_script:
+before_install:
   - pecl install -f mongodb-${DRIVER_VERSION}
   - composer update ${COMPOSER_FLAGS}
   - if [ "x$LEGACY_DRIVER_VERSION" != "x" ]; then yes '' | pecl -q install -f mongo-${LEGACY_DRIVER_VERSION}; fi
 
 script:
-    - ./vendor/bin/phpunit --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
-    - wget https://scrutinizer-ci.com/ocular.phar
-    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -1241,8 +1241,12 @@ class MongoCollectionTest extends TestCase
             'nIndexesWas' => 2,
             'errmsg' => 'index not found with name [bar_1]',
             'ok' => 0.0,
-            'code' => 27,
         ];
+
+        if (version_compare($this->getServerVersion(), '3.4.0', '>=')) {
+            $expected['code'] = 27;
+        }
+
         $this->assertEquals($expected, $this->getCollection()->deleteIndex('bar'));
 
         $this->assertCount(2, iterator_to_array($newCollection->listIndexes()));
@@ -1296,17 +1300,23 @@ class MongoCollectionTest extends TestCase
         $expected = [
             'ok' => 0.0,
             'errmsg' => 'ns not found',
-            'code' => 26,
         ];
-        $this->assertSame($expected, $this->getcollection('nonExisting')->deleteIndexes());
+
+        if (version_compare($this->getServerVersion(), '3.4.0', '>=')) {
+            $expected['code'] = 26;
+        }
+
+        $this->assertSame($expected, $this->getCollection('nonExisting')->deleteIndexes());
     }
 
-    public static function dataGetIndexInfo()
+    public function dataGetIndexInfo()
     {
+        $indexVersion = $this->getDefaultIndexVersion();
+
         return [
             'plainIndex' => [
                 'expectedIndex' => [
-                    'v' => 1,
+                    'v' => $indexVersion,
                     'key' => ['foo' => 1],
                     'name' => 'foo_1',
                     'ns' => 'mongo-php-adapter.test',
@@ -1316,7 +1326,7 @@ class MongoCollectionTest extends TestCase
             ],
             'uniqueIndex' => [
                 'expectedIndex' => [
-                    'v' => 1,
+                    'v' => $indexVersion,
                     'key' => ['foo' => 1],
                     'name' => 'foo_1',
                     'ns' => 'mongo-php-adapter.test',
@@ -1327,7 +1337,7 @@ class MongoCollectionTest extends TestCase
             ],
             'sparseIndex' => [
                 'expectedIndex' => [
-                    'v' => 1,
+                    'v' => $indexVersion,
                     'key' => ['foo' => 1],
                     'name' => 'foo_1',
                     'ns' => 'mongo-php-adapter.test',
@@ -1338,7 +1348,7 @@ class MongoCollectionTest extends TestCase
             ],
             'ttlIndex' => [
                 'expectedIndex' => [
-                    'v' => 1,
+                    'v' => $indexVersion,
                     'key' => ['foo' => 1],
                     'name' => 'foo_1',
                     'ns' => 'mongo-php-adapter.test',
@@ -1349,7 +1359,7 @@ class MongoCollectionTest extends TestCase
             ],
             'textIndex' => [
                 'expectedIndex' => [
-                    'v' => 1,
+                    'v' => $indexVersion,
                     'key' => [
                         '_fts' => 'text',
                         '_ftsx' => 1,
@@ -1361,14 +1371,14 @@ class MongoCollectionTest extends TestCase
                     ],
                     'default_language' => 'english',
                     'language_override' => 'language',
-                    'textIndexVersion' => 3,
+                    'textIndexVersion' => version_compare($this->getServerVersion(), '3.2.0', '>=') ? 3 : 2,
                 ],
                 'fields' => ['foo' => 'text'],
                 'options' => [],
             ],
             'partialFilterExpression' => [
                 'expectedIndex' => [
-                    'v' => 1,
+                    'v' => $indexVersion,
                     'key' => ['foo' => 1],
                     'name' => 'foo_1',
                     'ns' => 'mongo-php-adapter.test',
@@ -1383,18 +1393,18 @@ class MongoCollectionTest extends TestCase
             ],
             'geoSpatial' => [
                 'expectedIndex' => [
-                    'v' => 1,
+                    'v' => $indexVersion,
                     'key' => ['foo' => '2dsphere'],
                     'name' => 'foo_2dsphere',
                     'ns' => 'mongo-php-adapter.test',
-                    '2dsphereIndexVersion' => 3,
+                    '2dsphereIndexVersion' => version_compare($this->getServerVersion(), '3.2.0', '>=') ? 3 : 2,
                 ],
                 'fields' => ['foo' => '2dsphere'],
                 'options' => [],
             ],
             'geoHaystack' => [
                 'expectedIndex' => [
-                    'v' => 1,
+                    'v' => $indexVersion,
                     'key' => ['foo' => 'geoHaystack', 'bar' => 1],
                     'name' => 'foo_geoHaystack_bar_1',
                     'ns' => 'mongo-php-adapter.test',
@@ -1412,7 +1422,7 @@ class MongoCollectionTest extends TestCase
     public function testGetIndexInfo($expectedIndex, $fields, $options)
     {
         $idIndex = [
-            'v' => 1,
+            'v' => $this->getDefaultIndexVersion(),
             'key' => ['_id' => 1],
             'name' => '_id_',
             'ns' => 'mongo-php-adapter.test',

--- a/tests/Alcaeus/MongoDbAdapter/TestCase.php
+++ b/tests/Alcaeus/MongoDbAdapter/TestCase.php
@@ -163,4 +163,23 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Test only applies when running against mongo-php-adapter');
         }
     }
+
+    /**
+     * @return string
+     */
+    protected function getServerVersion()
+    {
+        $serverInfo = $this->getDatabase()->command(['buildinfo' => true]);
+        return $serverInfo['version'];
+    }
+
+    /**
+     * Indexes created in MongoDB 3.4 default to v: 2.
+     * @return int
+     * @see https://docs.mongodb.com/manual/release-notes/3.4-compatibility/#backwards-incompatible-features
+     */
+    protected function getDefaultIndexVersion()
+    {
+        return version_compare($this->getServerVersion(), '3.4.0', '>=') ? 2 : 1;
+    }
 }


### PR DESCRIPTION
Problem: Indexes created in MongoDB 3.4 [default to v: 2]( https://docs.mongodb.com/manual/release-notes/3.4-compatibility/#backwards-incompatible-features).

This feature can be controlled by MongoDB server parameter `featureCompatibilityVersion`. 

I have changed the test case's expected output from `createIndex` to expect different version depending on the MongoDB version number.

This PR also adds Travis test matrix for MongoDB server 3.4.