### PR TITLE
Allow PHPUnit 6.x on PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   fast_finish: true
   include:
     - php: 5.6
-      env: DRIVER_VERSION=stable LEGACY_DRIVER_VERSION=stable COMPOSER_FLAGS="--prefer-dist --prefer-lowest" SERVER_VERSION=3.0 COLUMNS=80
+      env: DRIVER_VERSION=stable LEGACY_DRIVER_VERSION=stable COMPOSER_FLAGS="--prefer-dist --prefer-lowest" SERVER_VERSION=3.0
       addons:
         apt:
           sources:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "mongodb/mongodb": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.4"
+        "phpunit/phpunit": "^5.7 || ^6.0"
     },
     "provide": {
         "ext-mongo": "1.6.14"

--- a/tests/Alcaeus/MongoDbAdapter/ExceptionConverterTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/ExceptionConverterTest.php
@@ -4,8 +4,9 @@ namespace Alcaeus\MongoDbAdapter\Tests;
 
 use MongoDB\Driver\Exception;
 use Alcaeus\MongoDbAdapter\ExceptionConverter;
+use PHPUnit\Framework\TestCase;
 
-class ExceptionConverterTest extends \PHPUnit_Framework_TestCase
+class ExceptionConverterTest extends TestCase
 {
     /**
      * @dataProvider exceptionProvider

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -24,14 +24,16 @@ class MongoClientTest extends TestCase
 
     public function testSelectDBWithEmptyName()
     {
-        $this->setExpectedException('Exception', 'Database name cannot be empty');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Database name cannot be empty');
 
         $this->getClient()->selectDB('');
     }
 
     public function testSelectDBWithInvalidName()
     {
-        $this->setExpectedException('Exception', 'Database name contains invalid characters');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Database name contains invalid characters');
 
         $this->getClient()->selectDB('/');
     }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
@@ -56,7 +56,7 @@ class MongoCursorTest extends TestCase
         $client = $this->getClient(['connect' => false], 'mongodb://localhost:28888');
         $cursor = $client->selectCollection('mongo-php-adapter', 'test')->find();
 
-        $this->setExpectedException('MongoConnectionException');
+        $this->expectException(\MongoConnectionException::class);
 
         $cursor->count();
     }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
@@ -17,14 +17,16 @@ class MongoDBTest extends TestCase
 
     public function testEmptyDatabaseName()
     {
-        $this->setExpectedException('Exception', 'Database name cannot be empty');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Database name cannot be empty');
 
         new \MongoDB($this->getClient(), '');
     }
 
     public function testInvalidDatabaseName()
     {
-        $this->setExpectedException('Exception', 'Database name contains invalid characters');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Database name contains invalid characters');
 
         new \MongoDB($this->getClient(), '/');
     }
@@ -41,7 +43,8 @@ class MongoDBTest extends TestCase
     {
         $database = $this->getDatabase();
 
-        $this->setExpectedException('Exception', 'Collection name cannot be empty');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Collection name cannot be empty');
 
         $database->selectCollection('');
     }
@@ -50,7 +53,8 @@ class MongoDBTest extends TestCase
     {
         $database = $this->getDatabase();
 
-        $this->setExpectedException('Exception', 'Collection name cannot contain null bytes');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Collection name cannot contain null bytes');
 
         $database->selectCollection('foo' . chr(0));
     }
@@ -257,7 +261,7 @@ class MongoDBTest extends TestCase
 
         $this->failMaxTimeMS();
 
-        $this->setExpectedException('MongoExecutionTimeoutException');
+        $this->expectException(\MongoExecutionTimeoutException::class);
 
         $database->getCollectionNames(['maxTimeMS' => 1]);
     }
@@ -286,7 +290,7 @@ class MongoDBTest extends TestCase
 
         $this->failMaxTimeMS();
 
-        $this->setExpectedException('MongoExecutionTimeoutException');
+        $this->expectException(\MongoExecutionTimeoutException::class);
 
         $database->getCollectionInfo(['maxTimeMS' => 1]);
     }
@@ -342,7 +346,7 @@ class MongoDBTest extends TestCase
     {
         $this->failMaxTimeMS();
 
-        $this->setExpectedException('MongoExecutionTimeoutException');
+        $this->expectException(\MongoExecutionTimeoutException::class);
 
         $this->getDatabase()->listCollections(['maxTimeMS' => 1]);
     }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
@@ -63,7 +63,8 @@ class MongoDeleteBatchTest extends TestCase
         $collection = $this->getCollection();
         $batch = new \MongoDeleteBatch($collection);
 
-        $this->setExpectedException('Exception', "Expected \$item to contain 'q' key");
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Expected \$item to contain 'q' key");
 
         $batch->add([]);
     }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
@@ -345,7 +345,8 @@ class MongoGridFSTest extends TestCase
         $document = ['_id' => $id];
         $collection->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->expectException(\MongoGridFSException::class);
+        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
 
         $collection->storeBytes('foo', ['_id' => $id]);
     }
@@ -358,7 +359,8 @@ class MongoGridFSTest extends TestCase
         $document = ['n' => 0];
         $collection->chunks->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
+        $this->expectException(\MongoGridFSException::class);
+        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
 
         $collection->storeBytes('foo');
     }
@@ -371,7 +373,8 @@ class MongoGridFSTest extends TestCase
         $document = ['_id' => $id];
         $collection->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->expectException(\MongoGridFSException::class);
+        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
 
         $collection->storeFile(__FILE__, ['_id' => $id]);
     }
@@ -384,7 +387,8 @@ class MongoGridFSTest extends TestCase
         $document = ['n' => 0];
         $collection->chunks->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
+        $this->expectException(\MongoGridFSException::class);
+        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
 
         $collection->storeFile(__FILE__);
     }
@@ -397,7 +401,8 @@ class MongoGridFSTest extends TestCase
         $document = ['length' => filesize(__FILE__)];
         $collection->insert($document);
 
-        $this->setExpectedExceptionRegExp('MongoGridFSException', '/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->expectException(\MongoGridFSException::class);
+        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
 
         $collection->storeFile(fopen(__FILE__, 'r'));
     }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoLogTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoLogTest.php
@@ -4,7 +4,7 @@ namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
 
-class MongoLogTest extends \PHPUnit_Framework_Testcase
+class MongoLogTest extends Testcase
 {
     public function testSetCallback()
     {

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
@@ -180,7 +180,8 @@ class MongoUpdateBatchTest extends TestCase
         $collection = $this->getCollection();
         $batch = new \MongoUpdateBatch($collection);
 
-        $this->setExpectedException('Exception', "Expected \$item to contain 'q' key");
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Expected \$item to contain 'q' key");
 
         $batch->add([]);
     }

--- a/tests/Alcaeus/MongoDbAdapter/TestCase.php
+++ b/tests/Alcaeus/MongoDbAdapter/TestCase.php
@@ -3,8 +3,9 @@
 namespace Alcaeus\MongoDbAdapter\Tests;
 
 use MongoDB\Client;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
     protected function tearDown()
     {


### PR DESCRIPTION
The bump to PHPUnit 5.7 for PHP 5.6 should also fix errors in the build environment