### PR TITLE
Add tests for authentication options

### DIFF
--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -225,6 +225,32 @@ class MongoClientTest extends TestCase
         ];
     }
 
+    public function testConnectWithUsernameAndPassword()
+    {
+        $this->expectException(\MongoConnectionException::class);
+        $this->expectExceptionMessage('Authentication failed');
+
+        $client = $this->getClient(['username' => 'alcaeus', 'password' => 'mySuperSecurePassword']);
+        $collection = $client->selectCollection('test', 'foo');
+
+        $document = ['foo' => 'bar'];
+
+        $collection->insert($document);
+    }
+    
+    public function testConnectWithUsernameAndPasswordInConnectionUrl()
+    {
+        $this->expectException(\MongoConnectionException::class);
+        $this->expectExceptionMessage('Authentication failed');
+
+        $client = $this->getClient([], 'mongodb://alcaeus:mySuperSecurePassword@localhost');
+        $collection = $client->selectCollection('test', 'foo');
+
+        $document = ['foo' => 'bar'];
+
+        $collection->insert($document);
+    }
+
     /**
      * @param array $options
      * @return string


### PR DESCRIPTION
This adds tests for the `username` and `password` authentication options. Currently, the tests expect an authentication failure to avoid a more complex setup to run all tests.