### PR TITLE
bug/deleteIndex fixed

### DIFF
--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -660,17 +660,22 @@ class MongoCollection
      *
      * @link http://www.php.net/manual/en/mongocollection.deleteindex.php
      * @param string|array $keys Field or fields from which to delete the index.
+     * @param bool $keysAsIndexNames treat keys explicitly as index names
      * @return array Returns the database response.
      */
-    public function deleteIndex($keys)
+    public function deleteIndex($keys, $keysAsIndexNames = false)
     {
         if (is_string($keys)) {
             $indexName = $keys;
-            if (! preg_match('#_-?1$#', $indexName)) {
-                $indexName .= '_1';
+            if (!$keysAsIndexNames) {
+                if (!preg_match('#_-?1$#', $indexName)) {
+                    $indexName .= '_1';
+                }
             }
         } elseif (is_array($keys)) {
-            $indexName = \MongoDB\generate_index_name($keys);
+            if (!$keysAsIndexNames) {
+                $indexName = \MongoDB\generate_index_name($keys);
+            }
         } else {
             throw new \InvalidArgumentException();
         }


### PR DESCRIPTION
so, you can specify your own name for index:
https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#ensureindex-options
No need to to build it automatically in this case.
There's still bug though in this method, cause for string $keys it can handle only simple indexes like:
createIndex({"ts": -1})
It's gonna fail for text index like:
createIndex({"$**": "text"})
