### PR TITLE
Fix php 7.2 warning

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/Helper/ReadPreference.php
+++ b/lib/Alcaeus/MongoDbAdapter/Helper/ReadPreference.php
@@ -110,7 +110,7 @@ trait ReadPreference
                 return false;
         }
 
-        if ($readPreference == \MongoClient::RP_PRIMARY && count($tags)) {
+        if ($readPreference == \MongoClient::RP_PRIMARY && !empty($tags)) {
             trigger_error("You can't use read preference tags with a read preference of PRIMARY", E_USER_WARNING);
             return false;
         }


### PR DESCRIPTION
Starting with PHP 7.2 count generates a warning unless the argument is an array or an object implementing the Countable interface.