### PR TITLE
Fix exception handling in forceConnect and update

### DIFF
--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -336,8 +336,12 @@ class MongoClient
      */
     private function forceConnect()
     {
-        $command = new \MongoDB\Driver\Command(['ping' => 1]);
-        $this->manager->executeCommand('db', $command);
+        try {
+            $command = new \MongoDB\Driver\Command(['ping' => 1]);
+            $this->manager->executeCommand('db', $command);
+        } catch (\MongoDB\Driver\Exception\Exception $e) {
+            throw ExceptionConverter::toLegacy($e);
+        }
     }
 
     private function notImplemented()

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -376,6 +376,8 @@ class MongoCollection
      */
     public function update(array $criteria, array $newobj, array $options = [])
     {
+        $this->checkKeys($newobj);
+
         $multiple = isset($options['multiple']) ? $options['multiple'] : false;
         $isReplace = ! \MongoDB\is_first_key_operator($newobj);
 
@@ -976,26 +978,27 @@ class MongoCollection
         return $options;
     }
 
+    private function checkKeys($array)
+    {
+        foreach (array_keys($array) as $key) {
+            if (empty($key) && $key !== 0) {
+                throw new \MongoException('zero-length keys are not allowed, did you use $ with double quotes?');
+            }
+        }
+    }
+
     /**
      * @param array|object $document
      * @return MongoId
      */
     private function ensureDocumentHasMongoId(&$document)
     {
-        $checkKeys = function ($array) {
-            foreach (array_keys($array) as $key) {
-                if (empty($key) && $key !== 0) {
-                    throw new \MongoException('zero-length keys are not allowed, did you use $ with double quotes?');
-                }
-            }
-        };
-
         if (is_array($document)) {
             if (! isset($document['_id'])) {
                 $document['_id'] = new \MongoId();
             }
 
-            $checkKeys($document);
+            $this->checkKeys($document);
 
             return $document['_id'];
         } elseif (is_object($document)) {
@@ -1010,7 +1013,7 @@ class MongoCollection
                 $document->_id = new \MongoId();
             }
 
-            $checkKeys((array) $document);
+            $this->checkKeys((array) $document);
 
             return $document->_id;
         }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -71,6 +71,15 @@ class MongoClientTest extends TestCase
         );
     }
 
+    public function testGetHostsExceptionHandling()
+    {
+        $this->expectException(\MongoConnectionException::class);
+        $this->expectExceptionMessageRegExp('/No suitable servers found/');
+
+        $client = $this->getClient(null, 'mongodb://fake_host');
+        $client->getHosts();
+    }
+
     public function testReadPreference()
     {
         $client = $this->getClient();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -74,7 +74,7 @@ class MongoClientTest extends TestCase
     public function testGetHostsExceptionHandling()
     {
         $this->expectException(\MongoConnectionException::class);
-        $this->expectExceptionMessageRegExp('/No suitable servers found/');
+        $this->expectExceptionMessageRegExp('/fake_host/');
 
         $client = $this->getClient(null, 'mongodb://fake_host');
         $client->getHosts();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -402,6 +402,29 @@ class MongoCollectionTest extends TestCase
         $this->assertTrue($this->getCollection()->update($document, ['$set' => ['foo' => 'foo']], ['w' => 0]));
     }
 
+    public function testUpdateWithInvalidKey()
+    {
+        $document = ['foo' => 'bar'];
+        $this->getCollection()->insert($document);
+
+        $update_document = ['*' => 'foo'];
+        $this->getCollection()->update($document, $update_document);
+
+        $this->assertSame(1, $this->getCollection()->count(['*' => 'foo']));
+    }
+
+    public function testUpdateWithEmptyKey()
+    {
+        $document = ['foo' => 'bar'];
+        $this->getCollection()->insert($document);
+
+        $this->expectException(\MongoException::class);
+        $this->expectExceptionMessage('zero-length keys are not allowed, did you use $ with double quotes?');
+
+        $update_document = ['' => 'foo'];
+        $this->getCollection()->update($document, $update_document);
+    }
+
     public function testRemoveMultiple()
     {
         $document = ['change' => true, 'foo' => 'bar'];


### PR DESCRIPTION
Ensure MongoCollection update checks keys of new document to prevent empty keys; also ensure forceConnect converts exceptions toLegacy

Resolves https://github.com/alcaeus/mongo-php-adapter/issues/192