### PR TITLE
Add method to free memory for abstract cursor

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -420,4 +420,10 @@ abstract class AbstractCursor
 
         return $this->current;
     }
+
+    public function freeMemory()
+    {
+        unset($this->iterator);
+        unset($this->cursor);
+    }
 }


### PR DESCRIPTION
Iterator is an instance of generator which keeps reference to the instance of mongo cursor. 

When I create many many requests with cursor, GC does not free memory for iterator and cursor (probably due to cross reference - both of them are properties of one object). 

That is why i added new method freeMemory that could be optionally called to unset these objects.