### PR TITLE
Fix write batch execution broken with w=0

### DIFF
--- a/lib/Mongo/MongoWriteBatch.php
+++ b/lib/Mongo/MongoWriteBatch.php
@@ -132,6 +132,17 @@ class MongoWriteBatch
 
         switch ($this->batchType) {
             case self::COMMAND_UPDATE:
+                if ($options['writeConcern']->getW() === 0) {
+                    $resultDocument += [
+                        'nMatched' => 0,
+                        'nModified' => 0,
+                        'nUpserted' => 0,
+                        'ok' => true,
+                    ];
+
+                    break;
+                }
+
                 $upsertedIds = [];
                 foreach ($writeResult->getUpsertedIds() as $index => $id) {
                     $upsertedIds[] = [
@@ -153,6 +164,15 @@ class MongoWriteBatch
                 break;
 
             case self::COMMAND_DELETE:
+                if ($options['writeConcern']->getW() === 0) {
+                    $resultDocument += [
+                        'nRemoved' => 0,
+                        'ok' => true,
+                    ];
+
+                    break;
+                }
+
                 $resultDocument += [
                     'nRemoved' => $writeResult->getDeletedCount(),
                     'ok' => true,
@@ -160,6 +180,15 @@ class MongoWriteBatch
                 break;
 
             case self::COMMAND_INSERT:
+                if ($options['writeConcern']->getW() === 0) {
+                    $resultDocument += [
+                        'nInserted' => 0,
+                        'ok' => true,
+                    ];
+
+                    break;
+                }
+
                 $resultDocument += [
                     'nInserted' => $writeResult->getInsertedCount(),
                     'ok' => true,

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
@@ -58,6 +58,29 @@ class MongoDeleteBatchTest extends TestCase
         $this->assertSame(0, $newCollection->count());
     }
 
+    public function testDeleteManyWithoutAck()
+    {
+        $collection = $this->getCollection();
+        $batch = new \MongoDeleteBatch($collection);
+
+        $document = ['foo' => 'bar'];
+        $collection->insert($document);
+        unset($document['_id']);
+        $collection->insert($document);
+
+        $this->assertTrue($batch->add(['q' => ['foo' => 'bar'], 'limit' => 0]));
+
+        $expected = [
+            'nRemoved' => 0,
+            'ok' => true,
+        ];
+
+        $this->assertSame($expected, $batch->execute(['w' => 0]));
+
+        $newCollection = $this->getCheckDatabase()->selectCollection('test');
+        $this->assertSame(0, $newCollection->count());
+    }
+
     public function testValidateItem()
     {
         $collection = $this->getCollection();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
@@ -34,6 +34,28 @@ class MongoInsertBatchTest extends TestCase
         $this->assertAttributeSame('bar', 'foo', $record);
     }
 
+    public function testInsertBatchWithoutAck()
+    {
+        $batch = new \MongoInsertBatch($this->getCollection());
+
+        $this->assertTrue($batch->add(['foo' => 'bar']));
+        $this->assertTrue($batch->add(['bar' => 'foo']));
+
+        $expected = [
+            'nInserted' => 0,
+            'ok' => true,
+        ];
+
+        $this->assertSame($expected, $batch->execute(['w' => 0]));
+
+        $newCollection = $this->getCheckDatabase()->selectCollection('test');
+        $this->assertSame(2, $newCollection->count());
+        $record = $newCollection->findOne();
+        $this->assertNotNull($record);
+        $this->assertObjectHasAttribute('foo', $record);
+        $this->assertAttributeSame('bar', 'foo', $record);
+    }
+
     public function testInsertBatchError()
     {
         $collection = $this->getCollection();


### PR DESCRIPTION
When executing a write batch with a "no ack" write concern (i.e. w=0), the result map must have no information (all counters set to 0) except ok=true in case of success.
