### PR TITLE
Remove reference to HHVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ compatible with PHP 7.
 This library aims to provide a compatibility layer for applications that rely on
 libraries using ext-mongo, e.g.
 [Doctrine MongoDB ODM](https://github.com/doctrine/mongodb-odm), but want to
-migrate to PHP 7 or HHVM on which `ext-mongo` will not run.
+migrate to PHP 7 on which `ext-mongo` will not run.
 
 You should not be using this library if you do not rely on a library using
 `ext-mongo`. If you are starting a new project, please check out


### PR DESCRIPTION
We don't support ext-mongodb for HHVM any more, so remove its reference.