### PR TITLE
Allow using PHPUnit 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "mongodb/mongodb": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0",
+        "phpunit/phpunit": "^5.7.27 || ^6.0 || ^7.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "provide": {


### PR DESCRIPTION
Also bumps the minimum PHPUnit dependency to the latest 5.7 version for compatibility reasons.