### PR TITLE
Allow "0" to be used as a key

### DIFF
--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -983,7 +983,7 @@ class MongoCollection
     private function checkKeys(array $array)
     {
         foreach ($array as $key => $value) {
-            if (empty($key) && $key !== 0) {
+            if (empty($key) && $key !== 0 && $key !== '0') {
                 throw new \MongoException('zero-length keys are not allowed, did you use $ with double quotes?');
             }
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -130,6 +130,20 @@ class MongoCollectionTest extends TestCase
         $this->assertSame(1, $this->getCollection()->count(['foo']));
     }
 
+	public function testInsertWithAlphaNumbericKey()
+    {
+		/**
+		 * Force the array to store the key as a string "0".
+		 * Initialising like ['0' => 'foo'] casts the string to an int.
+		 */
+		$document = new \stdClass();
+		$document->{'0'} = 'foo';
+		$document = (array) $document;
+		
+       	$this->getCollection()->insert($document);
+        $this->assertSame(1, $this->getCollection()->count(['0' => 'foo']));
+	}
+	
     public function testInsertDuplicate()
     {
         $collection = $this->getCollection();


### PR DESCRIPTION
Currently, if you try to insert a document with the following structure...
```
{
	"example":{
		"0": "abc",
		"1": "def",
	}
}
```
... the following exception is then thrown:
```
zero-length keys are not allowed, did you use $ with double quotes?'
```

However, MongoDB accepts this format.  This PR ensures the string `"0"` isn't caught by the `empty` check which causes the exception to be thrown

