### PR TITLE
Ensure options in mongo uri of integer type to be integers after extracting them

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
+        "ext-ctype": "*",
         "ext-hash": "*",
         "ext-mongodb": "^1.2.0",
         "mongodb/mongodb": "^1.0.1"

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -376,6 +376,8 @@ class MongoClient
             $keyValue = explode('=', $option);
             if ($keyValue[0] === 'readPreferenceTags') {
                 $options[$keyValue[0]][] = $this->getReadPreferenceTags($keyValue[1]);
+            } elseif (ctype_digit($keyValue[1])) {
+                $options[$keyValue[0]] = (int) $keyValue[1];
             } else {
                 $options[$keyValue[0]] = $keyValue[1];
             }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -283,7 +283,6 @@ class MongoClientTest extends TestCase
     {
         $client = new \MongoClient('mongodb://localhost/db?w=0&wtimeout=0', ['connect' => false]);
 
-        $this->skipTestIf(extension_loaded('mongo'));
         $this->assertSame(['w' => 0, 'wtimeout' => 0], $client->getWriteConcern());
     }
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -279,6 +279,14 @@ class MongoClientTest extends TestCase
         $collection->insert($document);
     }
 
+    public function testConnectionUriOptionIntegerTypeCasting()
+    {
+        $client = new \MongoClient('mongodb://localhost/db?w=0&wtimeout=0', ['connect' => false]);
+
+        $this->skipTestIf(extension_loaded('mongo'));
+        $this->assertSame(['w' => 0, 'wtimeout' => 0], $client->getWriteConcern());
+    }
+
     /**
      * @param array $options
      * @return string


### PR DESCRIPTION
I ran into an issue where mongo wasn't able to handle the provided MongoClient option 'w' as it was provided as a **string** type although an **integer** type was expected.
In my error case I provided "mongodb://localhost/db?w=0" as mongo uri, which caused mongo to give back the following error:
`“Could not store file: No write concern mode named ‘0’ found in replica set configuration”`

mongo looks for a write concern mode named (string) "0" where it should've been (number) 0 (https://docs.mongodb.com/v3.4/reference/write-concern/#wc-w)

I hope the fix I provided is ok. This is one of my first contributions to the OS community, so I'm happy to receive any feedback.

@alcaeus _big thanks for maintaining the adapter, I thankfully use it in several projects!_