### PR TITLE
support manually specifying an _id of "0"

### DIFF
--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -3,6 +3,16 @@ CHANGELOG for 1.1.x
 
 This changelog references the relevant changes done in minor version updates.
 
+1.1.9 (2019-08-07)
+------------------
+
+All issues and pull requests under this release may be found under the
+[1.1.9](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.1.9)
+milestone.
+
+ * [#255](https://github.com/alcaeus/mongo-php-adapter/pull/255) fixes inserting
+ documents with identifiers PHP considers empty.
+
 1.1.8 (2019-07-14)
 ------------------
 

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -277,7 +277,7 @@ class MongoCollection
      */
     public function insert(&$a, array $options = [])
     {
-        if (! $this->ensureDocumentHasMongoId($a)) {
+        if ($this->ensureDocumentHasMongoId($a) === null) {
             trigger_error(sprintf('%s(): expects parameter %d to be an array or object, %s given', __METHOD__, 1, gettype($a)), E_USER_WARNING);
             return;
         }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -80,6 +80,34 @@ class MongoCollectionTest extends TestCase
         $this->assertSame(1, $this->getCollection()->count(['_id' => $document['_id']]));
     }
 
+    /**
+     * @dataProvider emptyIdProvider
+     */
+    public function testInsertArrayWithEmptyIds($id)
+    {
+        $document = ['_id' => $id];
+        $this->getCollection()->insert($document);
+
+        $this->assertSame(1, $this->getCollection()->count(['_id' => $id]));
+    }
+
+    public function emptyIdProvider()
+    {
+        return [
+            'Zero as string' => ['0'],
+            'Zero as int' => [0],
+            'Empty string' => [''],
+        ];
+    }
+
+    public function testInsertArrayWithEmptyId()
+    {
+        $document = ['_id' => ''];
+        $this->getCollection()->insert($document);
+
+        $this->assertSame(1, $this->getCollection()->count(['_id' => $document['_id']]));
+    }
+
     public function testInsertEmptyObject()
     {
         $document = (object) [];


### PR DESCRIPTION
Enable the ability to insert documents with _id = 0