### PR TITLE
Fix cursor interface inheritance

### DIFF
--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -28,7 +28,7 @@ use MongoDB\Operation\Find;
  * Result object for database query.
  * @link http://www.php.net/manual/en/class.mongocursor.php
  */
-class MongoCursor extends AbstractCursor implements Iterator, Countable
+class MongoCursor extends AbstractCursor implements Iterator, Countable, MongoCursorInterface
 {
     /**
      * @var bool

--- a/lib/Mongo/MongoGridFSCursor.php
+++ b/lib/Mongo/MongoGridFSCursor.php
@@ -17,7 +17,7 @@ if (class_exists('MongoGridFSCursor', false)) {
     return;
 }
 
-class MongoGridFSCursor extends MongoCursor
+class MongoGridFSCursor extends MongoCursor implements Countable
 {
     /**
      * @static

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCommandCursorTest.php
@@ -2,6 +2,7 @@
 
 namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
+use MongoCursorInterface;
 use MongoDB\Database;
 use MongoDB\Driver\ReadPreference;
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
@@ -201,5 +202,13 @@ class MongoCommandCursorTest extends TestCase
                 ReadPreference::RP_SECONDARY,
             ],
         ];
+    }
+
+    public function testInterfaces()
+    {
+        $this->prepareData();
+        $cursor = $this->getCollection()->aggregateCursor([['$match' => ['foo' => 'bar']]]);
+
+        $this->assertInstanceOf(MongoCursorInterface::class, $cursor);
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
@@ -4,6 +4,8 @@ namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
 use Alcaeus\MongoDbAdapter\TypeConverter;
+use Countable;
+use MongoCursorInterface;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Find;
@@ -514,6 +516,19 @@ class MongoCursorTest extends TestCase
         ];
 
         $this->assertArraySubset($expected, $cursor->explain());
+    }
+
+    public function testInterfaces()
+    {
+        $collection = $this->getCollection();
+        $cursor = $collection->find();
+
+        $this->assertInstanceOf(MongoCursorInterface::class, $cursor);
+
+        // The countable interface is necessary for compatibility with PHP 7.3+, but not implemented by MongoCursor
+        if (! extension_loaded('mongo')) {
+            $this->assertInstanceOf(Countable::class, $cursor);
+        }
     }
 
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSCursorTest.php
@@ -3,6 +3,7 @@
 namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
+use Countable;
 
 class MongoGridFSCursorTest extends TestCase
 {
@@ -36,5 +37,17 @@ class MongoGridFSCursorTest extends TestCase
                 'md5' => 'acbd18db4cc2f85cedef654fccc4a4d8'
             ], $value->file);
         }
+    }
+
+    public function testInterfaces()
+    {
+        $this->skipTestIf(extension_loaded('mongo'));
+
+        $gridfs = $this->getGridFS();
+        $id = $gridfs->storeBytes('foo', ['filename' => 'foo.txt']);
+        $gridfs->storeBytes('bar', ['filename' => 'bar.txt']);
+
+        $cursor = $gridfs->find(['filename' => 'foo.txt']);
+        $this->assertInstanceOf(Countable::class, $cursor);
     }
 }


### PR DESCRIPTION
* While #259 added the `implements` declaration for `MongoCursor`, this also needed to be added to `MongoGridFS`
* I noticed that `MongoCursor` never implemented `MongoCursorInterface`, this has now been fixed
* Added tests to ensure that `MongoCommandCursor` implements `MongoCursorInterface`