### PR TITLE
Fix memory leak due to partially iterated generators

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -52,7 +52,7 @@ abstract class AbstractCursor
     protected $db;
 
     /**
-     * @var \Iterator
+     * @var CursorIterator
      */
     protected $iterator;
 
@@ -129,11 +129,6 @@ abstract class AbstractCursor
         if ($collectionName) {
             $this->collection = $connection->selectCollection($dbName, $collectionName)->getCollection();
         }
-    }
-
-    public function __destruct()
-    {
-        $this->iterator = null;
     }
 
     /**
@@ -297,9 +292,8 @@ abstract class AbstractCursor
     protected function ensureIterator()
     {
         if ($this->iterator === null) {
-            // MongoDB\Driver\Cursor needs to be wrapped into a \Generator so that a valid \Iterator with working implementations of
-            // next, current, valid, key and rewind is returned. These methods don't work if we wrap the Cursor inside an \IteratorIterator
             $this->iterator = $this->wrapTraversable($this->ensureCursor());
+            $this->iterator->rewind();
         }
 
         return $this->iterator;
@@ -307,13 +301,11 @@ abstract class AbstractCursor
 
     /**
      * @param \Traversable $traversable
-     * @return \Generator
+     * @return CursorIterator
      */
     protected function wrapTraversable(\Traversable $traversable)
     {
-        foreach ($traversable as $key => $value) {
-            yield $key => $value;
-        }
+        return new CursorIterator($traversable);
     }
 
     /**

--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -131,6 +131,11 @@ abstract class AbstractCursor
         }
     }
 
+    public function __destruct()
+    {
+        $this->iterator = null;
+    }
+
     /**
      * Returns the current element
      * @link http://www.php.net/manual/en/mongocursor.current.php

--- a/lib/Alcaeus/MongoDbAdapter/CursorIterator.php
+++ b/lib/Alcaeus/MongoDbAdapter/CursorIterator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Alcaeus\MongoDbAdapter;
+
+use IteratorIterator;
+use MongoDB\BSON\ObjectID;
+use Traversable;
+
+/**
+ * @internal
+ */
+final class CursorIterator extends IteratorIterator
+{
+    /** @var bool */
+    private $useIdAsKey;
+
+    public function __construct(Traversable $iterator, $useIdAsKey = false)
+    {
+        parent::__construct($iterator);
+
+        $this->useIdAsKey = $useIdAsKey;
+    }
+
+    public function key()
+    {
+        if (!$this->useIdAsKey) {
+            return parent::key();
+        }
+
+        $current = $this->current();
+
+        if (!isset($current->_id) || (is_object($current->_id) && !$current->_id instanceof ObjectID)) {
+            return parent::key();
+        }
+
+        return (string) $current->_id;
+    }
+}

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -18,6 +18,7 @@ if (class_exists('MongoCursor', false)) {
 }
 
 use Alcaeus\MongoDbAdapter\AbstractCursor;
+use Alcaeus\MongoDbAdapter\CursorIterator;
 use Alcaeus\MongoDbAdapter\TypeConverter;
 use Alcaeus\MongoDbAdapter\ExceptionConverter;
 use MongoDB\Driver\Cursor;
@@ -472,16 +473,11 @@ class MongoCursor extends AbstractCursor implements Iterator, Countable, MongoCu
 
     /**
      * @param \Traversable $traversable
-     * @return \Generator
+     * @return CursorIterator
      */
     protected function wrapTraversable(\Traversable $traversable)
     {
-        foreach ($traversable as $key => $value) {
-            if (isset($value->_id) && ($value->_id instanceof \MongoDB\BSON\ObjectID || !is_object($value->_id))) {
-                $key = (string) $value->_id;
-            }
-            yield $key => $value;
-        }
+        return new CursorIterator($traversable, true);
     }
 
     /**


### PR DESCRIPTION
The cursor classes wrap a given traversable in a generator. However, even when the cursors are garbage collected, the generator itself sometimes stays around and thus causes a memory leak. Thus, we remove our reference to the generator when destructing the cursor which also allows freeing the underlying MongoDB cursor object.