### PR TITLE
Fix typo in package description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "alcaeus/mongo-php-adapter",
     "type": "library",
-    "description": "Adapter to provide ext-mongo interface on top of mongo-php-libary",
+    "description": "Adapter to provide ext-mongo interface on top of mongo-php-library",
     "keywords": ["mongodb", "database"],
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
There is no "mongo-php-libary"