### PR TITLE
Always return 1 for health in MongoClient::getHosts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
     # Test against legacy driver to ensure validity of the test suite
     - stage: Test
       php: 5.6
+      env: DRIVER_VERSION="1.7.5"
       install:
         - yes '' | pecl -q install -f mongo
 

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -222,7 +222,7 @@ class MongoClient
             $results[$key] = [
                 'host' => $server->getHost(),
                 'port' => $server->getPort(),
-                'health' => (int) $info['ok'],
+                'health' => 1,
                 'state' => $state,
                 'ping' => $server->getLatency(),
                 'lastPing' => null,


### PR DESCRIPTION
Fixes #270.
Looking at the legacy driver, this has always returned 1 since the method was refactored waaay back in 2012. It's safe to say that we don't need to rely on a field from the `isMaster` response.