### PR TITLE
Use PHPUnit bridge to test on multiple PHP versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 composer.lock
 .phpcs-cache
+.phpunit.result.cache
 vendor/
 tests/scripts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - composer update ${COMPOSER_FLAGS}
 
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/simple-phpunit
 
 jobs:
   include:
@@ -37,7 +37,7 @@ jobs:
     - stage: test
       php: 7.3
       script:
-        - vendor/bin/phpunit --coverage-clover=coverage.clover
+        - vendor/bin/simple-phpunit --coverage-clover=coverage.clover
       after_script:
         - wget https://scrutinizer-ci.com/ocular.phar
         - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
@@ -45,7 +45,7 @@ jobs:
     # Test against legacy driver to ensure validity of the test suite
     - stage: Test
       php: 5.6
-      env: DRIVER_VERSION="1.7.5"
+      env: DRIVER_VERSION="1.7.5" SYMFONY_DEPRECATIONS_HELPER=9999999
       install:
         - yes '' | pecl -q install -f mongo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "mongodb/mongodb": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^4.4 || ^5.1",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "provide": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          stopOnFailure="false"
+         bootstrap="vendor/autoload.php"
 >
     <php>
         <!-- Disable deprecation warnings -->

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoBinDataTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoBinDataTest.php
@@ -15,8 +15,8 @@ class MongoBinDataTest extends TestCase
     public function testCreate()
     {
         $bin = new \MongoBinData(self::GUID, \MongoBinData::FUNC);
-        $this->assertAttributeSame(self::GUID, 'bin', $bin);
-        $this->assertAttributeSame(\MongoBinData::FUNC, 'type', $bin);
+        $this->assertSame(self::GUID, $bin->bin);
+        $this->assertSame(\MongoBinData::FUNC, $bin->type);
 
         $this->assertSame('<Mongo Binary Data>', (string) $bin);
 
@@ -44,7 +44,7 @@ class MongoBinDataTest extends TestCase
         $bsonBinary = new \MongoDB\BSON\Binary(self::GUID, \MongoDB\BSON\Binary::TYPE_UUID);
         $bin = new \MongoBinData($bsonBinary);
 
-        $this->assertAttributeSame(self::GUID, 'bin', $bin);
-        $this->assertAttributeSame(\MongoBinData::UUID_RFC4122, 'type', $bin);
+        $this->assertSame(self::GUID, $bin->bin);
+        $this->assertSame(\MongoBinData::UUID_RFC4122, $bin->type);
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -30,7 +30,7 @@ class MongoClientTest extends TestCase
 
     public function testSerialize()
     {
-        $this->assertInternalType('string', serialize($this->getClient()));
+        $this->assertIsString(serialize($this->getClient()));
     }
 
     public function testGetDb()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCodeTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCodeTest.php
@@ -4,6 +4,7 @@ namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
 use Alcaeus\MongoDbAdapter\TypeInterface;
+use ReflectionProperty;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -13,8 +14,9 @@ class MongoCodeTest extends TestCase
     public function testCreate()
     {
         $code = new \MongoCode('code', ['scope' => 'bleh']);
-        $this->assertAttributeSame('code', 'code', $code);
-        $this->assertAttributeSame(['scope' => 'bleh'], 'scope', $code);
+
+        $this->assertSame('code', $this->getAttributeValue($code, 'code'));
+        $this->assertSame(['scope' => 'bleh'], $this->getAttributeValue($code, 'scope'));
 
         $this->assertSame('code', (string) $code);
 
@@ -39,7 +41,15 @@ class MongoCodeTest extends TestCase
         $bsonCode = new \MongoDB\BSON\Javascript('code', ['scope' => 'bleh']);
         $code = new \MongoCode($bsonCode);
 
-        $this->assertAttributeSame('code', 'code', $code);
-        $this->assertAttributeSame(['scope' => 'bleh'], 'scope', $code);
+        $this->assertSame('code', $this->getAttributeValue($code, 'code'));
+        $this->assertSame(['scope' => 'bleh'], $this->getAttributeValue($code, 'scope'));
+    }
+
+    private function getAttributeValue(\MongoCode $code, $attribute)
+    {
+        $property = new ReflectionProperty($code, $attribute);
+        $property->setAccessible(true);
+
+        return $property->getValue($code);
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -17,7 +17,7 @@ class MongoCollectionTest extends TestCase
 {
     public function testSerialize()
     {
-        $this->assertInternalType('string', serialize($this->getCollection()));
+        $this->assertIsString(serialize($this->getCollection()));
     }
 
     public function testGetNestedCollections()
@@ -802,7 +802,7 @@ class MongoCollectionTest extends TestCase
         $this->prepareData();
 
         $values = $this->getCollection()->distinct('foo');
-        $this->assertInternalType('array', $values);
+        $this->assertIsArray($values);
 
         sort($values);
         $this->assertEquals(['bar', 'foo'], $values);
@@ -813,7 +813,7 @@ class MongoCollectionTest extends TestCase
         $this->prepareData();
 
         $values = $this->getCollection()->distinct('foo', ['foo' => 'bar']);
-        $this->assertInternalType('array', $values);
+        $this->assertIsArray($values);
         $this->assertEquals(['bar'], $values);
     }
 
@@ -864,7 +864,7 @@ class MongoCollectionTest extends TestCase
         ];
 
         $result = $collection->aggregate($pipeline, ['cursor' => true]);
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertArrayHasKey('result', $result);
 
         $this->assertEquals([
@@ -900,7 +900,7 @@ class MongoCollectionTest extends TestCase
             $this->fail($msg);
         }
 
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertArrayHasKey('result', $result);
 
         $this->assertEquals([
@@ -1449,17 +1449,14 @@ class MongoCollectionTest extends TestCase
 
     public function testDeleteIndexesForNonExistingCollection()
     {
-        $expected = [
-            'ok' => 0.0,
-            'errmsg' => 'ns not found',
-        ];
+        $result = $this->getCollection('nonExisting')->deleteIndexes();
 
+        $this->assertSame(0.0, $result['ok']);
+        $this->assertRegExp('#ns not found#', $result['errmsg']);
         if (version_compare($this->getServerVersion(), '3.4.0', '>=')) {
+            $this->assertSame(26, $result['code']);
             $expected['code'] = 26;
         }
-
-        // Using assertArraySubset because newer versions (3.4.7?) also return `codeName`
-        $this->assertArraySubset($expected, $this->getCollection('nonExisting')->deleteIndexes());
     }
 
     public function dataGetIndexInfo()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCommandCursorTest.php
@@ -16,7 +16,7 @@ class MongoCommandCursorTest extends TestCase
     {
         $this->prepareData();
         $cursor = $this->getCollection()->aggregateCursor([['$match' => ['foo' => 'bar']]]);
-        $this->assertInternalType('string', serialize($cursor));
+        $this->assertIsString(serialize($cursor));
     }
 
     public function testInfo()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
@@ -19,7 +19,7 @@ class MongoCursorTest extends TestCase
     {
         $this->prepareData();
         $cursor = $this->getCollection()->find(['foo' => 'bar']);
-        $this->assertInternalType('string', serialize($cursor));
+        $this->assertIsString(serialize($cursor));
     }
 
     public function testCursorConvertsTypes()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBRefTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBRefTest.php
@@ -85,7 +85,7 @@ class MongoDBRefTest extends TestCase
         $db->selectCollection('test')->insert($document);
 
         $fetchedRef = \MongoDBRef::get($db, ['$ref' => 'test', '$id' => $id]);
-        $this->assertInternalType('array', $fetchedRef);
+        $this->assertIsArray($fetchedRef);
         $this->assertEquals($document, $fetchedRef);
     }
 
@@ -99,7 +99,7 @@ class MongoDBRefTest extends TestCase
         $db->selectCollection('test')->insert($document);
 
         $fetchedRef = $db->getDBRef(['$ref' => 'test', '$id' => $id]);
-        $this->assertInternalType('array', $fetchedRef);
+        $this->assertIsArray($fetchedRef);
         $this->assertEquals($document, $fetchedRef);
     }
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
@@ -12,7 +12,7 @@ class MongoDBTest extends TestCase
 {
     public function testSerialize()
     {
-        $this->assertInternalType('string', serialize($this->getDatabase()));
+        $this->assertIsString(serialize($this->getDatabase()));
     }
 
     public function testEmptyDatabaseName()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
@@ -32,8 +32,8 @@ class MongoDateTest extends TestCase
     public function testCreate()
     {
         $date = new \MongoDate(1234567890, 123456);
-        $this->assertAttributeSame(1234567890, 'sec', $date);
-        $this->assertAttributeSame(123000, 'usec', $date);
+        $this->assertSame(1234567890, $date->sec);
+        $this->assertSame(123000, $date->usec);
 
         $this->assertSame('0.12300000 1234567890', (string) $date);
         $dateTime = $date->toDateTime();
@@ -68,8 +68,8 @@ class MongoDateTest extends TestCase
     public function testCreateWithString()
     {
         $date = new \MongoDate('1234567890', '123456');
-        $this->assertAttributeSame(1234567890, 'sec', $date);
-        $this->assertAttributeSame(123000, 'usec', $date);
+        $this->assertSame(1234567890, $date->sec);
+        $this->assertSame(123000, $date->usec);
     }
 
     public function testCreateWithBsonDate()
@@ -79,15 +79,15 @@ class MongoDateTest extends TestCase
         $bsonDate = new \MongoDB\BSON\UTCDateTime(1234567890123);
         $date = new \MongoDate($bsonDate);
 
-        $this->assertAttributeSame(1234567890, 'sec', $date);
-        $this->assertAttributeSame(123000, 'usec', $date);
+        $this->assertSame(1234567890, $date->sec);
+        $this->assertSame(123000, $date->usec);
     }
 
     public function testSupportMillisecondsWithLeadingZeroes()
     {
         $date = new \MongoDate('1234567890', '012345');
-        $this->assertAttributeSame(1234567890, 'sec', $date);
-        $this->assertAttributeSame(12000, 'usec', $date);
+        $this->assertSame(1234567890, $date->sec);
+        $this->assertSame(12000, $date->usec);
 
         $this->assertSame('0.01200000 1234567890', (string) $date);
         $dateTime = $date->toDateTime();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
@@ -9,7 +9,7 @@ class MongoDeleteBatchTest extends TestCase
     public function testSerialize()
     {
         $batch = new \MongoDeleteBatch($this->getCollection());
-        $this->assertInternalType('string', serialize($batch));
+        $this->assertIsString(serialize($batch));
     }
 
     public function testDeleteOne()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSCursorTest.php
@@ -14,7 +14,7 @@ class MongoGridFSCursorTest extends TestCase
         $gridfs->storeBytes('bar', ['filename' => 'bar.txt']);
         $cursor = $gridfs->find(['filename' => 'foo.txt']);
 
-        $this->assertInternalType('string', serialize($cursor));
+        $this->assertIsString(serialize($cursor));
     }
 
     public function testCursorItems()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSFileTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSFileTest.php
@@ -12,7 +12,7 @@ class MongoGridFSFileTest extends TestCase
         $file = $this->getGridFS()->findOne(['filename' => 'foo']);
         $this->assertInstanceOf(\MongoGridFSFile::class, $file);
 
-        $this->assertInternalType('string', serialize($file));
+        $this->assertIsString(serialize($file));
     }
 
     public function testFileProperty()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
@@ -8,7 +8,7 @@ class MongoGridFSTest extends TestCase
 {
     public function testSerialize()
     {
-        $this->assertInternalType('string', serialize($this->getGridFS()));
+        $this->assertIsString(serialize($this->getGridFS()));
     }
 
     public function testChunkProperty()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoIdTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoIdTest.php
@@ -4,6 +4,7 @@ namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
 use MongoDB\BSON\ObjectID;
+use ReflectionProperty;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -40,12 +41,11 @@ class MongoIdTest extends TestCase
         $this->assertSame(34335, $id->getPID());
     }
 
-    /**
-     * @expectedException \MongoException
-     * @expectedExceptionMessage Invalid object ID
-     */
     public function testCreateWithInvalidStringThrowsMongoException()
     {
+        $this->expectException('\MongoException');
+        $this->expectExceptionMessage('Invalid object ID');
+
         new \MongoId('invalid');
     }
 
@@ -59,7 +59,7 @@ class MongoIdTest extends TestCase
         $id = new \MongoId($objectId);
         $this->assertSame($original, (string) $id);
 
-        $this->assertAttributeNotSame($objectId, 'objectID', $id);
+        $this->assertNotSame($objectId, $this->getAttributeValue($id, 'objectID'));
     }
 
     /**
@@ -82,5 +82,13 @@ class MongoIdTest extends TestCase
             'invalidString' => [false, 'abc'],
             'object' => [false, new \stdClass()],
         ];
+    }
+
+    private function getAttributeValue(\MongoId $id, $attribute)
+    {
+        $property = new ReflectionProperty($id, $attribute);
+        $property->setAccessible(true);
+
+        return $property->getValue($id);
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
@@ -9,7 +9,7 @@ class MongoInsertBatchTest extends TestCase
     public function testSerialize()
     {
         $batch = new \MongoInsertBatch($this->getCollection());
-        $this->assertInternalType('string', serialize($batch));
+        $this->assertIsString(serialize($batch));
     }
 
     public function testInsertBatch()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoRegexTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoRegexTest.php
@@ -13,8 +13,8 @@ class MongoRegexTest extends TestCase
     public function testCreate()
     {
         $regex = new \MongoRegex('/abc/i');
-        $this->assertAttributeSame('abc', 'regex', $regex);
-        $this->assertAttributeSame('i', 'flags', $regex);
+        $this->assertSame('abc', $regex->regex);
+        $this->assertSame('i', $regex->flags);
 
         $this->assertSame('/abc/i', (string) $regex);
 
@@ -41,7 +41,7 @@ class MongoRegexTest extends TestCase
         $bsonRegex = new \MongoDB\BSON\Regex('abc', 'i');
         $regex = new \MongoRegex($bsonRegex);
 
-        $this->assertAttributeSame('abc', 'regex', $regex);
-        $this->assertAttributeSame('i', 'flags', $regex);
+        $this->assertSame('abc', $regex->regex);
+        $this->assertSame('i', $regex->flags);
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoTimestampTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoTimestampTest.php
@@ -13,8 +13,8 @@ class MongoTimestampTest extends TestCase
     public function testCreate()
     {
         $timestamp = new \MongoTimestamp(1234567890, 987654321);
-        $this->assertAttributeSame(1234567890, 'sec', $timestamp);
-        $this->assertAttributeSame(987654321, 'inc', $timestamp);
+        $this->assertSame(1234567890, $timestamp->sec);
+        $this->assertSame(987654321, $timestamp->inc);
 
         $this->assertSame('1234567890', (string) $timestamp);
 
@@ -38,8 +38,8 @@ class MongoTimestampTest extends TestCase
         $timestamp1 = new \MongoTimestamp(1234567890);
         $timestamp2 = new \MongoTimestamp(1234567890);
 
-        $this->assertAttributeSame(0, 'inc', $timestamp1);
-        $this->assertAttributeSame(1, 'inc', $timestamp2);
+        $this->assertSame(0, $timestamp1->inc);
+        $this->assertSame(1, $timestamp2->inc);
     }
 
     public function testCreateWithBsonTimestamp()
@@ -49,8 +49,8 @@ class MongoTimestampTest extends TestCase
         $bsonTimestamp = new \MongoDB\BSON\Timestamp(987654321, 1234567890);
         $timestamp = new \MongoTimestamp($bsonTimestamp);
 
-        $this->assertAttributeSame(1234567890, 'sec', $timestamp);
-        $this->assertAttributeSame(987654321, 'inc', $timestamp);
+        $this->assertSame(1234567890, $timestamp->sec);
+        $this->assertSame(987654321, $timestamp->inc);
     }
 
     public function testContructorArgumentOrderDiffers()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
@@ -9,7 +9,7 @@ class MongoUpdateBatchTest extends TestCase
     public function testSerialize()
     {
         $batch = new \MongoUpdateBatch($this->getCollection());
-        $this->assertInternalType('string', serialize($batch));
+        $this->assertIsString(serialize($batch));
     }
 
     public function testUpdateOne()

--- a/tests/Alcaeus/MongoDbAdapter/TestCase.php
+++ b/tests/Alcaeus/MongoDbAdapter/TestCase.php
@@ -4,15 +4,20 @@ namespace Alcaeus\MongoDbAdapter\Tests;
 
 use MongoDB\Client;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 abstract class TestCase extends BaseTestCase
 {
+    use SetUpTearDownTrait;
+
     const INDEX_VERSION_1 = 1;
     const INDEX_VERSION_2 = 2;
 
-    protected function tearDown()
+    private function doTearDown()
     {
         $this->getCheckDatabase()->drop();
+
+        parent::tearDown();
     }
 
     /**


### PR DESCRIPTION
This PR removes the direct dependency on PHPUnit in favour of the Symfony PHPUnit bridge, as it allows for easier testing against a wide range of PHP versions, as required by this package.