### PR TITLE
Fix converting DateTimeInterface to BSON in php 7.4

### DIFF
--- a/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
@@ -43,6 +43,8 @@ class TypeConverter
                 return $value->toBSONType();
             case $value instanceof BSON\Type:
                 return $value;
+            case $value instanceof \DateTimeInterface:
+                return self::fromLegacy((array) $value);
             case is_array($value):
             case is_object($value):
                 $result = [];

--- a/tests/Alcaeus/MongoDbAdapter/TypeConverterTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/TypeConverterTest.php
@@ -37,6 +37,14 @@ class TypeConverterTest extends TestCase
             'nestedArrays' => [
                 [['foo' => 'bar']], [new BSONDocument(['foo' => 'bar'])]
             ],
+            'dateTime'            => [
+                \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2021-06-30T12:34:56-7'),
+                new BSONDocument([
+                    'date'          => '2021-06-30 12:34:56.000000',
+                    'timezone_type' => 1,
+                    'timezone'      => '-07:00',
+                ]),
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #282
PHP 7.4 changed foreach behavior for DateTime object (https://bugs.php.net/bug.php?id=79041)
Converting a \DateTimeInterface object gives an empty BSONDocument