### PR TITLE
Fix PHPUnit issues

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,12 +21,6 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./lib/Alcaeus/MongoDbAdapter</directory>
-        </whitelist>
-    </filter>
-
     <php>
         <const name="MONGODB_URI" value="mongodb://localhost:27017" />
     </php>

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -93,7 +93,7 @@ class MongoClientTest extends TestCase
     public function testGetHostsExceptionHandling()
     {
         $this->expectException(\MongoConnectionException::class);
-        $this->expectExceptionMessageRegExp('/fake_host/');
+        $this->expectErrorMessageMatches('/fake_host/');
 
         $client = $this->getClient(null, 'mongodb://fake_host');
         $client->getHosts();
@@ -265,7 +265,7 @@ class MongoClientTest extends TestCase
 
         $collection->insert($document);
     }
-    
+
     public function testConnectWithUsernameAndPasswordInConnectionUrl()
     {
         $this->expectException(\MongoConnectionException::class);

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -195,7 +195,7 @@ class MongoCollectionTest extends TestCase
         unset($document['_id']);
 
         $this->expectException(\MongoDuplicateKeyException::class);
-        $this->expectExceptionMessageRegExp('/E11000 duplicate key error .* mongo-php-adapter\.test/');
+        $this->expectErrorMessageMatches('/E11000 duplicate key error .* mongo-php-adapter\.test/');
         $this->expectExceptionCode(11000);
         $collection->insert($document);
     }
@@ -303,7 +303,7 @@ class MongoCollectionTest extends TestCase
         $documents = [['_id' => $id, 'foo' => 'bar'], ['_id' => $id, 'foo' => 'bleh']];
 
         $this->expectException(\MongoDuplicateKeyException::class);
-        $this->expectExceptionMessageRegExp('/E11000 duplicate key error .* mongo-php-adapter.test.*_id_/');
+        $this->expectErrorMessageMatches('/E11000 duplicate key error .* mongo-php-adapter.test.*_id_/');
         $this->expectExceptionCode(11000);
 
         $this->getCollection()->batchInsert($documents);
@@ -415,7 +415,7 @@ class MongoCollectionTest extends TestCase
     public function testUpdateReplaceMultiple()
     {
         $this->expectException(\MongoWriteConcernException::class);
-        $this->expectExceptionMessageRegExp('/multi update only works with \$ operators/', 9);
+        $this->expectErrorMessageMatches('/multi update only works with \$ operators/', 9);
         $this->getCollection()->update(['foo' => 'bar'], ['foo' => 'foo'], ['multiple' => true]);
     }
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
@@ -327,7 +327,7 @@ class MongoGridFSTest extends TestCase
         $collection->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
         $this->expectExceptionCode(11000);
 
         $collection->storeBytes('foo', ['_id' => $id]);
@@ -342,7 +342,7 @@ class MongoGridFSTest extends TestCase
         $collection->chunks->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
+        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
         $this->expectExceptionCode(11000);
 
         $collection->storeBytes('foo');
@@ -357,7 +357,7 @@ class MongoGridFSTest extends TestCase
         $collection->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
         $this->expectExceptionCode(11000);
 
         $collection->storeFile(__FILE__, ['_id' => $id]);
@@ -372,7 +372,7 @@ class MongoGridFSTest extends TestCase
         $collection->chunks->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
+        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
         $this->expectExceptionCode(11000);
 
         $collection->storeFile(__FILE__);
@@ -387,7 +387,7 @@ class MongoGridFSTest extends TestCase
         $collection->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectExceptionMessageRegExp('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
         $this->expectExceptionCode(11000);
 
         $collection->storeFile(fopen(__FILE__, 'r'));


### PR DESCRIPTION
Running with PHPUnit 9.4.4 causes failures due to the tests relying on `expectExceptionMessageRegExp`. This PR fixes those issues.