### PR TITLE
Php8.1 serializable

### DIFF
--- a/lib/Mongo/MongoId.php
+++ b/lib/Mongo/MongoId.php
@@ -219,6 +219,7 @@ class MongoId implements Serializable, TypeInterface, JsonSerializable
     /**
      * @return stdClass
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $object = new stdClass();

--- a/lib/Mongo/MongoId.php
+++ b/lib/Mongo/MongoId.php
@@ -143,6 +143,23 @@ class MongoId implements Serializable, TypeInterface, JsonSerializable
     }
 
     /**
+     * @return string[]
+     */
+    public function __serialize()
+    {
+        return [$this->serialize()];
+    }
+
+    /**
+     * @param string[] $data
+     * @return void
+     */
+    public function __unserialize($data)
+    {
+        $this->unserialize($data[0]);
+    }
+
+    /**
      * Gets the incremented value to create this id
      * @link http://php.net/manual/en/mongoid.getinc.php
      * @return int Returns the incremented value used to create this MongoId.


### PR DESCRIPTION
The MongoId class caused two serialization-related deprecation messages when used with PHP 8.1.
These changes should get rid of the warnings on 8.1 while still being backwards compatible with all PHP versions listed in the composer.json.