### PR TITLE
remove "Deprecated" message in php 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,13 @@
 {
-    "name": "alcaeus/mongo-php-adapter",
+    "name": "nbsbbs/mongo-php-adapter",
     "type": "library",
-    "description": "Adapter to provide ext-mongo interface on top of mongo-php-library",
+    "description": "Adapter to provide ext-mongo interface on top of mongo-php-library (updated by Noobus)",
     "keywords": ["mongodb", "database"],
     "license": "MIT",
     "authors": [
         { "name": "alcaeus", "email": "alcaeus@alcaeus.org" },
-        { "name": "Olivier Lechevalier", "email": "olivier.lechevalier@gmail.com" }
+        { "name": "Olivier Lechevalier", "email": "olivier.lechevalier@gmail.com" },
+        { "name": "Noobus", "email": "nbsbbs@gmail.com" }
     ],
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",

--- a/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
@@ -178,7 +178,7 @@ class TypeConverter
             case $value instanceof Model\BSONDocument:
             case $value instanceof Model\BSONArray:
                 return array_map(
-                    ['self', 'toLegacy'],
+                    [self::class, 'toLegacy'],
                     $value->getArrayCopy()
                 );
             default:


### PR DESCRIPTION
calling ['self', 'toLegacy'] causes Deprecated error message in PHP 8.2.