### PR TITLE
Support readPreferenceTags as options array

### DIFF
--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -392,11 +392,15 @@ class MongoClient
     }
 
     /**
-     * @param $readPreferenceTagString
+     * @param string $readPreferenceTagString
      * @return array
      */
     private function getReadPreferenceTags($readPreferenceTagString)
     {
+        if ($readPreferenceTagString === '') {
+            return [];
+        }
+
         $tagSets = [];
         foreach (explode(',', $readPreferenceTagString) as $index => $tagSet) {
             $tags = explode(':', $tagSet);

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -86,7 +86,7 @@ class MongoClient
             $server = 'mongodb://' . self::DEFAULT_HOST . ':' . self::DEFAULT_PORT;
         }
 
-        if (isset($options['readPreferenceTags'])) {
+        if (isset($options['readPreferenceTags']) && is_string($options['readPreferenceTags'])) {
             $options['readPreferenceTags'] = [$this->getReadPreferenceTags($options['readPreferenceTags'])];
         }
 
@@ -426,7 +426,9 @@ class MongoClient
 
         // Special handling for readPreferenceTags which are merged
         if (isset($options['readPreferenceTags']) && isset($urlOptions['readPreferenceTags'])) {
-            $options['readPreferenceTags'] = array_merge($urlOptions['readPreferenceTags'], $options['readPreferenceTags']);
+            $mergedTagSets = array_merge($urlOptions['readPreferenceTags'], $options['readPreferenceTags']);
+            $uniqueTagSets = array_unique($mergedTagSets, SORT_REGULAR);
+            $options['readPreferenceTags'] = $uniqueTagSets;
             unset($urlOptions['readPreferenceTags']);
         }
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -340,7 +340,6 @@ class MongoClientTest extends TestCase
             if (is_array($value)) {
                 if ($key === 'readPreferenceTags') {
                     foreach ($value as $tagSet) {
-
                         $tagString = implode(',', array_map(
                             function ($k, $v) {
                                 return $k . ':' . $v;

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -15,7 +15,7 @@ class MongoClientTest extends TestCase
     public function testConnectionUri($uri, $expected)
     {
         $this->skipTestIf(extension_loaded('mongo'));
-        $this->assertSame($expected, (string)(new \MongoClient($uri, ['connect' => false])));
+        $this->assertSame($expected, (string) (new \MongoClient($uri, ['connect' => false])));
     }
 
     public function provideConnectionUri()
@@ -35,7 +35,7 @@ class MongoClientTest extends TestCase
         $client = $this->getClient();
         $db = $client->selectDB('mongo-php-adapter');
         $this->assertInstanceOf('\MongoDB', $db);
-        $this->assertSame('mongo-php-adapter', (string)$db);
+        $this->assertSame('mongo-php-adapter', (string) $db);
     }
 
     public function testSelectDBWithEmptyName()
@@ -59,7 +59,7 @@ class MongoClientTest extends TestCase
         $client = $this->getClient();
         $db = $client->{'mongo-php-adapter'};
         $this->assertInstanceOf('\MongoDB', $db);
-        $this->assertSame('mongo-php-adapter', (string)$db);
+        $this->assertSame('mongo-php-adapter', (string) $db);
     }
 
     public function testGetCollection()
@@ -67,7 +67,7 @@ class MongoClientTest extends TestCase
         $client = $this->getClient();
         $collection = $client->selectCollection('mongo-php-adapter', 'test');
         $this->assertInstanceOf('MongoCollection', $collection);
-        $this->assertSame('mongo-php-adapter.test', (string)$collection);
+        $this->assertSame('mongo-php-adapter.test', (string) $collection);
     }
 
     public function testGetHosts()


### PR DESCRIPTION
This pull requests propose changes to configuration options for MongoClient regarding `readPreferenceTags`.

Currently, read preference tags can be configured using string of comma-delimited sequence of colon-delimited key/value pairs.
Example:
```php
<?php
$options = [
    'readPreference' => 'secondary',
    'readPreferenceTags' => 'dc:east,use:reporting'
];

$m = new MongoClient("mongodb://localhost/", $options);
?>
```
There are limitation when using string syntax:
- unable to define multiple tag sets
- unable to define empty tag set

Proposed solution allow readPreferenceTags to be set using array syntax.
Same syntax is used when configuring tags using setter methods.
Example:
```php
<?php

$options = [
    'readPreference' => 'secondary',
    'readPreferenceTags' => [
    	['dc' => 'east', 'use' => 'reporting'],
    	['dc' => 'west'],
    	[]
    ]
];

$m = new MongoClient("mongodb://localhost/", $options);
?>
```
Configuration is backwards compatible, so users can continue to use old string syntax. 
If not necessary, it can be removed.