### PR TITLE
Use Ubuntu 20.04 for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   verification:
     name: "Verification tests"
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-20.04"
 
     steps:
       - name: "Checkout"
@@ -81,7 +81,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - "ubuntu-18.04"
+          - "ubuntu-20.04"
         php-version:
           - "7.2"
           - "7.3"
@@ -96,17 +96,17 @@ jobs:
           - "normal"
         include:
           - deps: "low"
-            os: "ubuntu-18.04"
+            os: "ubuntu-20.04"
             php-version: "5.6"
             mongodb-version: "3.0"
             driver-version: "1.2.0"
           - deps: "normal"
-            os: "ubuntu-18.04"
+            os: "ubuntu-20.04"
             php-version: "7.0"
             mongodb-version: "4.4"
             driver-version: "1.9.2"
           - deps: "normal"
-            os: "ubuntu-18.04"
+            os: "ubuntu-20.04"
             php-version: "7.1"
             mongodb-version: "4.4"
             driver-version: "1.11.1"


### PR DESCRIPTION
Ubuntu 18.04 was removed a while back. Let's see if Ubuntu 20.04 works without any big changes.