### PR TITLE
Support PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         mongodb-version:
           - "4.4"
         driver-version:

--- a/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/TypeConverter.php
@@ -178,7 +178,9 @@ class TypeConverter
             case $value instanceof Model\BSONDocument:
             case $value instanceof Model\BSONArray:
                 return array_map(
-                    ['self', 'toLegacy'],
+                    function ($value) {
+                        return self::toLegacy($value);
+                    },
                     $value->getArrayCopy()
                 );
             default:

--- a/lib/Mongo/MongoId.php
+++ b/lib/Mongo/MongoId.php
@@ -143,6 +143,28 @@ class MongoId implements Serializable, TypeInterface, JsonSerializable
     }
 
     /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return [
+            'objectID' => (string) $this->objectID
+        ];
+    }
+
+    /**
+     * @param  array  $data
+     * @return void
+     * @throws MongoException
+     */
+    public function __unserialize(array $data)
+    {
+        if (isset($data['objectID'])) {
+            $this->createObjectID($data['objectID']);
+        }
+    }
+
+    /**
      * Gets the incremented value to create this id
      * @link http://php.net/manual/en/mongoid.getinc.php
      * @return int Returns the incremented value used to create this MongoId.

--- a/tests/Alcaeus/MongoDbAdapter/Constraint/Matches.php
+++ b/tests/Alcaeus/MongoDbAdapter/Constraint/Matches.php
@@ -51,6 +51,9 @@ class Matches extends Constraint
     /** @var ComparisonFailure|null */
     private $lastFailure;
 
+    /** @var Factory */
+    private $comparatorFactory;
+
     public function __construct($value, $allowExtraRootKeys = true, $allowExtraKeys = false, $allowOperators = true)
     {
         $this->value = self::prepare($value);

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -89,11 +89,23 @@ class MongoClientTest extends TestCase
 
     public function testGetHostsExceptionHandling()
     {
-        $this->expectException(\MongoConnectionException::class);
-        $this->expectErrorMessageMatches('/fake_host/');
+        // Workaround for PHPUnit 10
+        set_error_handler(
+            static function ($errno, $errstr) {
+                throw new \Exception($errstr, $errno);
+            },
+            E_ALL
+        );
 
-        $client = $this->getClient(null, 'mongodb://fake_host');
-        $client->getHosts();
+        $this->expectException(\MongoConnectionException::class);
+        $this->expectExceptionMessageMatches('/fake_host/');
+
+        try {
+            $client = $this->getClient(null, 'mongodb://fake_host');
+            $client->getHosts();
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testReadPreference()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDeleteBatchTest.php
@@ -76,6 +76,7 @@ class MongoDeleteBatchTest extends TestCase
         ];
 
         $this->assertSame($expected, $batch->execute(['w' => 0]));
+        usleep(250000); // 250 ms
 
         $newCollection = $this->getCheckDatabase()->selectCollection('test');
         $this->assertSame(0, $newCollection->count());

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
@@ -327,7 +327,7 @@ class MongoGridFSTest extends TestCase
         $collection->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->expectExceptionMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
         $this->expectExceptionCode(11000);
 
         $collection->storeBytes('foo', ['_id' => $id]);
@@ -342,7 +342,7 @@ class MongoGridFSTest extends TestCase
         $collection->chunks->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
+        $this->expectExceptionMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
         $this->expectExceptionCode(11000);
 
         $collection->storeBytes('foo');
@@ -357,7 +357,7 @@ class MongoGridFSTest extends TestCase
         $collection->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->expectExceptionMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
         $this->expectExceptionCode(11000);
 
         $collection->storeFile(__FILE__, ['_id' => $id]);
@@ -372,7 +372,7 @@ class MongoGridFSTest extends TestCase
         $collection->chunks->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
+        $this->expectExceptionMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.chunks/');
         $this->expectExceptionCode(11000);
 
         $collection->storeFile(__FILE__);
@@ -387,7 +387,7 @@ class MongoGridFSTest extends TestCase
         $collection->insert($document);
 
         $this->expectException(\MongoGridFSException::class);
-        $this->expectErrorMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
+        $this->expectExceptionMessageMatches('/Could not store file:.* E11000 duplicate key error .* mongo-php-adapter\.fs\.files/');
         $this->expectExceptionCode(11000);
 
         $collection->storeFile(fopen(__FILE__, 'r'));

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoIdTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoIdTest.php
@@ -20,7 +20,14 @@ class MongoIdTest extends TestCase
         $this->assertSame($stringId, $id->{'$id'});
 
         $serialized = serialize($id);
-        $this->assertSame(sprintf('C:7:"MongoId":24:{%s}', $stringId), $serialized);
+
+        if (PHP_VERSION_ID >= 70400) {
+            $serializedStr = 'O:7:"MongoId":1:{s:8:"objectID";s:24:"%s";}';
+        } else {
+            $serializedStr = 'C:7:"MongoId":24:{%s}';
+        }
+
+        $this->assertSame(sprintf($serializedStr, $stringId), $serialized);
 
         $unserialized = unserialize($serialized);
         $this->assertInstanceOf('MongoId', $unserialized);

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
@@ -8,13 +8,13 @@ class MongoInsertBatchTest extends TestCase
 {
     public function testSerialize()
     {
-        $batch = new \MongoInsertBatch($this->getCollection());
+        $batch = new \MongoInsertBatch($this->getCollection('MongoInsertBatchTest_testSerialize'));
         $this->assertIsString(serialize($batch));
     }
 
     public function testInsertBatch()
     {
-        $batch = new \MongoInsertBatch($this->getCollection());
+        $batch = new \MongoInsertBatch($this->getCollection('MongoInsertBatchTest_testInsertBatch'));
 
         $this->assertTrue($batch->add(['foo' => 'bar']));
         $this->assertTrue($batch->add(['bar' => 'foo']));
@@ -26,7 +26,7 @@ class MongoInsertBatchTest extends TestCase
 
         $this->assertSame($expected, $batch->execute());
 
-        $newCollection = $this->getCheckDatabase()->selectCollection('test');
+        $newCollection = $this->getCheckDatabase()->selectCollection('MongoInsertBatchTest_testInsertBatch');
         $this->assertSame(2, $newCollection->count());
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
@@ -35,7 +35,7 @@ class MongoInsertBatchTest extends TestCase
 
     public function testInsertBatchWithoutAck()
     {
-        $batch = new \MongoInsertBatch($this->getCollection());
+        $batch = new \MongoInsertBatch($this->getCollection('MongoInsertBatchTest_testInsertBatchWithoutAck'));
 
         $this->assertTrue($batch->add(['foo' => 'bar']));
         $this->assertTrue($batch->add(['bar' => 'foo']));
@@ -46,8 +46,9 @@ class MongoInsertBatchTest extends TestCase
         ];
 
         $this->assertSame($expected, $batch->execute(['w' => 0]));
+        usleep(250000); // 250 ms
 
-        $newCollection = $this->getCheckDatabase()->selectCollection('test');
+        $newCollection = $this->getCheckDatabase()->selectCollection('MongoInsertBatchTest_testInsertBatchWithoutAck');
         $this->assertSame(2, $newCollection->count());
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
@@ -56,7 +57,7 @@ class MongoInsertBatchTest extends TestCase
 
     public function testInsertBatchError()
     {
-        $collection = $this->getCollection();
+        $collection = $this->getCollection('MongoInsertBatchTest_testInsertBatchError');
         $batch = new \MongoInsertBatch($collection);
         $collection->createIndex(['foo' => 1], ['unique' => true]);
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
@@ -122,6 +122,7 @@ class MongoUpdateBatchTest extends TestCase
         ];
 
         $this->assertSame($expected, $batch->execute(['w' => 0]));
+        usleep(250000); // 250 ms
 
         $newCollection = $this->getCheckDatabase()->selectCollection('test');
         $this->assertSame(2, $newCollection->count());


### PR DESCRIPTION
This pull request repairs the PHPUnit tests, adds support for PHPUnit 10 and fixes PHP 8.1 and 8.2 deprecation warnings.

The workflows for PHP 5.6 are still failing, because `mongodb-labs/drivers-evergreen-tools` installs `pymongo` with version 
 `4.5.0`, which is incompatible with mongodb version `3.0`:
> pymongo.errors.ConfigurationError: Server at localhost:27017 reports wire version 3, but this version of PyMongo requires at least 6 (MongoDB 3.6).

The behavior change of `serialize` for PHP 7.4 or higher might be considered a (minor) breaking change that with semantic versioning should result in a new major version. You can still `serialize` and `unserialize` within the same adapter and PHP version as before, but not exchange serialized data with older adapter or PHP versions.