### PR TITLE
Allow to create MongoClient using existing \MongoDB\Client

### DIFF
--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -96,13 +96,34 @@ class MongoClient
         if (false === strpos($this->server, '://')) {
             $this->server = 'mongodb://' . $this->server;
         }
-        $this->client = new Client($this->server, $options, $driverOptions + ['driver' => ['name' => 'mongo-php-adapter']]);
-        $info = $this->client->__debugInfo();
-        $this->manager = $info['manager'];
+        $client = new Client($this->server, $options, $driverOptions + ['driver' => ['name' => 'mongo-php-adapter']]);
+        $this->setClient($client);
 
         if (isset($options['connect']) && $options['connect']) {
             $this->connect();
         }
+    }
+
+    /**
+     * @return self
+     * @throws MongoConnectionException
+     */
+    public static function fromClient(Client $client)
+    {
+        $self = new self((string) $client);
+        $self->setClient($client);
+
+        return $self;
+    }
+
+    /**
+     * @return void
+     */
+    private function setClient(Client $client)
+    {
+        $this->client = $client;
+        $info = $client->__debugInfo();
+        $this->manager = $info['manager'];
     }
 
 
@@ -328,7 +349,7 @@ class MongoClient
      */
     public function __toString()
     {
-        return $this->server;
+        return (string) $this->client;
     }
 
     /**

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -3,6 +3,7 @@
 namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
+use MongoDB\Client;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -23,6 +24,13 @@ class MongoClientTest extends TestCase
         yield ['default', sprintf('mongodb://%s:%d', \MongoClient::DEFAULT_HOST, \MongoClient::DEFAULT_PORT)];
         yield ['localhost', 'mongodb://localhost'];
         yield ['mongodb://localhost', 'mongodb://localhost'];
+    }
+
+    public function testCreateFromClient()
+    {
+        $sourceClient = new Client();
+        $client = \MongoClient::fromClient($sourceClient);
+        self::assertSame($sourceClient, $client->getClient());
     }
 
     public function testSerialize()


### PR DESCRIPTION
Sometimes we need to have a single connection in case we use another library working with MongoDB (f.e. doctrine/mongodb-odm).

It would be cool to have an ability to inject custom,  already configured `\MongoDB\Client` client.